### PR TITLE
【実装】【追加】注文画面であて先を入力できるようにする #33

### DIFF
--- a/src/main/java/com/example/demo/controller/OrderController.java
+++ b/src/main/java/com/example/demo/controller/OrderController.java
@@ -66,6 +66,13 @@ public class OrderController {
 			RedirectAttributes redirectAttributes,
 			Model model) {
 
+		//	セッションに値を詰める
+		address.setPostNum(postNum);
+		address.setPrefecture(prefecture);
+		address.setMunicipality(municipality);
+		address.setHouseNum(houseNum);
+		address.setBuildingNameRoomNum(buildingNameRoomNum);
+
 		//	必須のバリデーション
 		if (postNum.equals("") || prefecture.equals("") || municipality.equals("") || houseNum.equals("")) {
 			redirectAttributes.addAttribute("errMes",

--- a/src/main/java/com/example/demo/controller/OrderController.java
+++ b/src/main/java/com/example/demo/controller/OrderController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import com.example.demo.entity.Item;
 import com.example.demo.entity.Order;
 import com.example.demo.entity.OrderDetail;
+import com.example.demo.model.Address;
 import com.example.demo.model.Cart;
 import com.example.demo.repository.OrderDetailRepository;
 import com.example.demo.repository.OrderRepository;
@@ -24,6 +25,9 @@ public class OrderController {
 	Cart cart;
 
 	@Autowired
+	Address address;
+
+	@Autowired
 	OrderRepository orderRepository;
 
 	@Autowired
@@ -31,7 +35,17 @@ public class OrderController {
 
 	// 注文画面表示
 	@GetMapping("/order")
-	public String index() {
+	public String index(Model model) {
+
+		//	都道府県の配列を画面に渡す
+		model.addAttribute("prefectureList", new String[] {
+				"北海道", "青森県", "岩手県", "宮城県", "秋田県", "山形県", "福島県",
+				"茨城県", "栃木県", "群馬県", "埼玉県", "千葉県", "東京都", "神奈川県",
+				"新潟県", "富山県", "石川県", "福井県", "山梨県", "長野県", "岐阜県",
+				"静岡県", "愛知県", "三重県", "滋賀県", "京都府", "大阪府", "兵庫県",
+				"奈良県", "和歌山県", "鳥取県", "島根県", "岡山県", "広島県", "山口県",
+				"徳島県", "香川県", "愛媛県", "高知県", "福岡県", "佐賀県", "長崎県",
+				"熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県" });
 
 		return "order";
 	}

--- a/src/main/java/com/example/demo/controller/OrderController.java
+++ b/src/main/java/com/example/demo/controller/OrderController.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.example.demo.entity.Item;
 import com.example.demo.entity.Order;
@@ -35,7 +37,9 @@ public class OrderController {
 
 	// 注文画面表示
 	@GetMapping("/order")
-	public String index(Model model) {
+	public String index(
+			@RequestParam(name = "errMes", defaultValue = "") String errMes,
+			Model model) {
 
 		//	都道府県の配列を画面に渡す
 		model.addAttribute("prefectureList", new String[] {
@@ -46,13 +50,28 @@ public class OrderController {
 				"奈良県", "和歌山県", "鳥取県", "島根県", "岡山県", "広島県", "山口県",
 				"徳島県", "香川県", "愛媛県", "高知県", "福岡県", "佐賀県", "長崎県",
 				"熊本県", "大分県", "宮崎県", "鹿児島県", "沖縄県" });
+		model.addAttribute("errMes", errMes);
 
 		return "order";
 	}
 
 	// 注文確認画面表示
-	@GetMapping("/order/confirm")
-	public String confirm() {
+	@PostMapping("/order/confirm")
+	public String confirm(
+			@RequestParam(value = "postNum", defaultValue = "") String postNum,
+			@RequestParam(value = "prefecture", defaultValue = "") String prefecture,
+			@RequestParam(value = "municipality", defaultValue = "") String municipality,
+			@RequestParam(value = "houseNum", defaultValue = "") String houseNum,
+			@RequestParam(value = "buildingNameRoomNum", defaultValue = "") String buildingNameRoomNum,
+			RedirectAttributes redirectAttributes,
+			Model model) {
+
+		//	必須のバリデーション
+		if (postNum.equals("") || prefecture.equals("") || municipality.equals("") || houseNum.equals("")) {
+			redirectAttributes.addAttribute("errMes",
+					"「建物名・部屋番号」以外は全て必須項目です。");
+			return "redirect:/order";
+		}
 
 		return "orderConfirm";
 	}

--- a/src/main/java/com/example/demo/model/Address.java
+++ b/src/main/java/com/example/demo/model/Address.java
@@ -1,0 +1,60 @@
+package com.example.demo.model;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.SessionScope;
+
+@Component
+@SessionScope
+public class Address {
+
+	private String postNum; // 郵便番号
+	private String prefecture; // 都道府県
+	private String municipality; // 市区町村
+	private String houseNum; // 番地
+	private String buildingNameRoomNum; // 建物名・部屋番号
+
+	public String getPostNum() {
+		return postNum;
+	}
+
+	public String getPrefecture() {
+		return prefecture;
+	}
+
+	public String getMunicipality() {
+		return municipality;
+	}
+
+	public String getHouseNum() {
+		return houseNum;
+	}
+
+	public String getBuildingNameRoomNum() {
+		return buildingNameRoomNum;
+	}
+
+	public void setPostNum(String postNum) {
+		this.postNum = postNum;
+	}
+
+	public void setPrefecture(String prefecture) {
+		this.prefecture = prefecture;
+	}
+
+	public void setMunicipality(String municipality) {
+		this.municipality = municipality;
+	}
+
+	public void setHouseNum(String houseNum) {
+		this.houseNum = houseNum;
+	}
+
+	public void setBuildingNameRoomNum(String buildingNameRoomNum) {
+		this.buildingNameRoomNum = buildingNameRoomNum;
+	}
+
+	//	指定された値が既にセットされている値と同じか
+	public boolean isPrefectureSet(String prefecture) {
+		return this.prefecture != null && this.prefecture.equals(prefecture);
+	}
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -152,6 +152,13 @@ main {
 	font-weight: bold;
 }
 
+/* 注文 */
+/* あて先入力 */
+.one-form-container {
+	display: flex;
+    flex-flow: column;
+}
+
 /* 注文完了 */
 .ordered-item {
 	background-color: rgb(255, 255, 255);

--- a/src/main/resources/templates/order.html
+++ b/src/main/resources/templates/order.html
@@ -37,7 +37,10 @@
 			</div>
 
 			<!-- あて先入力欄 -->
-			<div class="input-form">
+			<form action="/order/confirm" method="post" class="input-form">
+				<!-- エラーメッセージの表示 -->
+				<div class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</div>
+
 				<div class="one-form-container">
 					<label>郵便番号</label>
 					<input type="text" name="postNum" th:value="${@address.postNum}">
@@ -47,14 +50,14 @@
 					<select name="prefecture">
 						<option
 							th:each="prefecture:${prefectureList}"
-							th:value="${@address.postNum}">
+							th:value="${@address.prefecture != null && @address.prefecture.length > 0 ? @address.prefecture: prefecture}">
 							[[${prefecture}]]
 						</option>
 					</select>
 				</div>
 				<div class="one-form-container">
 					<label>市区町村</label>
-					<input type="text" name="municipalities" th:value="${@address.municipalities}">
+					<input type="text" name="municipality" th:value="${@address.municipality}">
 				</div>
 				<div class="one-form-container">
 					<label>番地</label>
@@ -64,16 +67,14 @@
 					<label>建物名・部屋番号</label>
 					<input type="text" name="buildingNameRoomNum" th:value="${@address.buildingNameRoomNum}">
 				</div>
-			</div>
 
-			<div class="order-buttons">
-				<a href="/cart">
-					<button>カートに戻る</button>
-				</a>
-				<a href="/order/confirm">
+				<div class="order-buttons">
+					<a href="/cart">
+						<button>カートに戻る</button>
+					</a>
 					<button>注文内容を確認する</button>
-				</a>
-			</div>
+				</div>
+			</form>
 		</div>
 	</main>
 

--- a/src/main/resources/templates/order.html
+++ b/src/main/resources/templates/order.html
@@ -35,6 +35,37 @@
 				<span>合計</span>
 				<span th:text="${@cart.totalPrice}"></span>
 			</div>
+
+			<!-- あて先入力欄 -->
+			<div class="input-form">
+				<div class="one-form-container">
+					<label>郵便番号</label>
+					<input type="text" name="postNum" th:value="${@address.postNum}">
+				</div>
+				<div class="one-form-container">
+					<label>都道府県</label>
+					<select name="prefecture">
+						<option
+							th:each="prefecture:${prefectureList}"
+							th:value="${@address.postNum}">
+							[[${prefecture}]]
+						</option>
+					</select>
+				</div>
+				<div class="one-form-container">
+					<label>市区町村</label>
+					<input type="text" name="municipalities" th:value="${@address.municipalities}">
+				</div>
+				<div class="one-form-container">
+					<label>番地</label>
+					<input type="text" name="houseNum" th:value="${@address.houseNum}">
+				</div>
+				<div class="one-form-container">
+					<label>建物名・部屋番号</label>
+					<input type="text" name="buildingNameRoomNum" th:value="${@address.buildingNameRoomNum}">
+				</div>
+			</div>
+
 			<div class="order-buttons">
 				<a href="/cart">
 					<button>カートに戻る</button>

--- a/src/main/resources/templates/order.html
+++ b/src/main/resources/templates/order.html
@@ -50,7 +50,8 @@
 					<select name="prefecture">
 						<option
 							th:each="prefecture:${prefectureList}"
-							th:value="${@address.prefecture != null && @address.prefecture.length > 0 ? @address.prefecture: prefecture}">
+							th:value="${prefecture}"
+							th:selected="${@address.isPrefectureSet(prefecture)}">
 							[[${prefecture}]]
 						</option>
 					</select>

--- a/src/main/resources/templates/orderConfirm.html
+++ b/src/main/resources/templates/orderConfirm.html
@@ -21,6 +21,30 @@
 				<button>この内容で注文</button>
 			</form>
 
+			<!-- あて先表示 -->
+			<div class="input-form">
+				<div>
+					<spqn>郵便番号：</spqn>
+					[[${@address.postNum}]]
+				</div>
+				<div>
+					<spqn>都道府県：</spqn>
+					[[${@address.prefecture}]]
+				</div>
+				<div>
+					<spqn>市区町村：</spqn>
+					[[${@address.municipality}]]
+				</div>
+				<div>
+					<spqn>番地：</spqn>
+					[[${@address.houseNum}]]
+				</div>
+				<div>
+					<spqn>建物名・部屋番号：</spqn>
+					[[${@address.buildingNameRoomNum}]]
+				</div>
+			</div>
+
 			<div class="column-center">
 				<div th:each="item:${@cart.items}" class="item-container column-center cart-item">
 					<div class="img-title-container">


### PR DESCRIPTION
### 目的
注文画面であて先が入力できるようにする

### 修正内容
 - 注文画面にあて先の入力フォームを表示
 - 注文画面にあて先の入力値を表示
 - 「建物名・部屋番号」以外は必須のバリデーションをあて先保存時に追加

### 仕様
 - あて先の各入力項目の不正な値などのバリデーションは実装していない
 - あて先の入力値をセッションで管理しているため、2回目以降の注文画面では前回の入力内容が残ったままになる
 　ー＞セッションをクリアする処理がどこかに必要？今のところログアウトすればすべてのセッション情報は破棄されるから保留
 - あて先保存時にバリデーションに引っかかった場合は、その入力値を保持する
 - 都道府県に関しては、サーバ側にて固定で配列の形で管理
 - デザインは一旦保留

### デモ
#### イメージ画像
![image](https://github.com/kanetatsu-biz/Spring-shopping-site/assets/123366737/9880c3ca-396f-453d-bab0-f1881bd3f020)
*注文画面*

![image](https://github.com/kanetatsu-biz/Spring-shopping-site/assets/123366737/daf2b569-dbfd-4c22-812c-0a1222c5a7d5)
*注文確認画面*

#### 手順
1. 商品をカートに追加し、カート画面から「注文画面に進む」を押下
2. 注文画面にてあて先入力フォームが表示されていることを確認し、「建物名・部屋番号」以外のすべての項目を入力し、「注文内容を確認する」を押下
3. 注文確認画面にて、2で入力した値が表示されていることを確認し、「この内容で注文」を押下
4. 注文完了画面が表示される

#### 追加で確認してほしいこと
 - 注文画面にて「建物名・部屋番号」以外のいずれかの項目を空白にした状態で、「注文内容を確認する」を押下すると、バリデーションエラーメッセージが表示されること

### 確認済み
 - ユーザーストーリーの更新
     - 確認画面のAPIを「GET」から「POST」に変更
     - あて先入力データをクエリパラメータとして追加、エラーメッセージも同様

### 関連しているタスク
 - #34 
 - #37 
 - #17 