### PR TITLE
【実装】【追加】注文に紐づくあて先情報をDBに保管する #37

### DIFF
--- a/src/main/java/com/example/demo/controller/OrderController.java
+++ b/src/main/java/com/example/demo/controller/OrderController.java
@@ -15,7 +15,6 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import com.example.demo.entity.Item;
 import com.example.demo.entity.Order;
 import com.example.demo.entity.OrderDetail;
-import com.example.demo.model.Address;
 import com.example.demo.model.Cart;
 import com.example.demo.repository.OrderDetailRepository;
 import com.example.demo.repository.OrderRepository;
@@ -25,9 +24,6 @@ public class OrderController {
 
 	@Autowired
 	Cart cart;
-
-	@Autowired
-	Address address;
 
 	@Autowired
 	OrderRepository orderRepository;

--- a/src/main/java/com/example/demo/entity/Address.java
+++ b/src/main/java/com/example/demo/entity/Address.java
@@ -1,17 +1,27 @@
-package com.example.demo.model;
+package com.example.demo.entity;
 
-import org.springframework.stereotype.Component;
-import org.springframework.web.context.annotation.SessionScope;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
-@Component
-@SessionScope
+@Entity
+@Table(name = "addresses")
 public class Address {
 
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id; // あて先ID
 	private String postNum; // 郵便番号
 	private String prefecture; // 都道府県
 	private String municipality; // 市区町村
 	private String houseNum; // 番地
 	private String buildingNameRoomNum; // 建物名・部屋番号
+
+	public Integer getId() {
+		return id;
+	}
 
 	public String getPostNum() {
 		return postNum;

--- a/src/main/java/com/example/demo/entity/Address.java
+++ b/src/main/java/com/example/demo/entity/Address.java
@@ -1,5 +1,6 @@
 package com.example.demo.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -13,10 +14,17 @@ public class Address {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Integer id; // あて先ID
+
+	@Column(name = "post_num")
 	private String postNum; // 郵便番号
+
 	private String prefecture; // 都道府県
 	private String municipality; // 市区町村
+
+	@Column(name = "house_num")
 	private String houseNum; // 番地
+
+	@Column(name = "building_name_room_num")
 	private String buildingNameRoomNum; // 建物名・部屋番号
 
 	public Integer getId() {

--- a/src/main/java/com/example/demo/entity/Order.java
+++ b/src/main/java/com/example/demo/entity/Order.java
@@ -25,15 +25,19 @@ public class Order {
 	@Column(name = "total_price")
 	private Integer totalPrice; // 合計金額
 
+	@Column(name = "address_id")
+	private Integer addressId; // あて先ID
+
 	// コンストラクタ
 	public Order() {
 		super();
 	}
 
-	public Order(Integer customerId, LocalDateTime orderedDatetime, Integer totalPrice) {
+	public Order(Integer customerId, LocalDateTime orderedDatetime, Integer totalPrice, Integer addressId) {
 		this.customerId = customerId;
 		this.orderedDatetime = orderedDatetime;
 		this.totalPrice = totalPrice;
+		this.addressId = addressId;
 	}
 
 	// ゲッター

--- a/src/main/java/com/example/demo/model/LoginUser.java
+++ b/src/main/java/com/example/demo/model/LoginUser.java
@@ -11,6 +11,10 @@ public class LoginUser {
 
 	private String name;
 
+	public Integer getId() {
+		return id;
+	}
+
 	public String getName() {
 		return name;
 	}

--- a/src/main/java/com/example/demo/repository/AddressRepository.java
+++ b/src/main/java/com/example/demo/repository/AddressRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.demo.entity.Address;
+
+public interface AddressRepository extends JpaRepository<Address, Integer> {
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,5 @@
 -- 各種テーブル削除
+DROP TABLE IF EXISTS addresses;
 DROP TABLE IF EXISTS order_details;
 DROP TABLE IF EXISTS orders;
 DROP TABLE IF EXISTS accounts;
@@ -51,4 +52,15 @@ CREATE TABLE order_details
    quantity INTEGER,
    FOREIGN KEY (order_id) REFERENCES orders(id),
    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+
+-- あて先テーブル
+CREATE TABLE addresses
+(
+   id SERIAL PRIMARY KEY,
+   postNum TEXT,
+   prefecture TEXT,
+   municipality TEXT,
+   houseNum TEXT,
+   buildingNameRoomNum TEXT
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,7 +1,7 @@
 -- 各種テーブル削除
-DROP TABLE IF EXISTS addresses;
 DROP TABLE IF EXISTS order_details;
 DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS addresses;
 DROP TABLE IF EXISTS accounts;
 DROP TABLE IF EXISTS items;
 DROP TABLE IF EXISTS categories;
@@ -33,6 +33,17 @@ CREATE TABLE accounts
    password TEXT
 );
 
+-- あて先テーブル
+CREATE TABLE addresses
+(
+   id SERIAL PRIMARY KEY,
+   post_num TEXT,
+   prefecture TEXT,
+   municipality TEXT,
+   house_num TEXT,
+   building_name_room_num TEXT
+);
+
 -- 注文テーブル
 CREATE TABLE orders
 (
@@ -40,7 +51,9 @@ CREATE TABLE orders
    customer_id INTEGER,
    ordered_datetime TIMESTAMP,
    total_price INTEGER,
-   FOREIGN KEY (customer_id) REFERENCES accounts(id)
+   address_id INTEGER,
+   FOREIGN KEY (customer_id) REFERENCES accounts(id),
+   FOREIGN KEY (address_id) REFERENCES addresses(id)
 );
 
 -- 注文詳細テーブル
@@ -52,15 +65,4 @@ CREATE TABLE order_details
    quantity INTEGER,
    FOREIGN KEY (order_id) REFERENCES orders(id),
    FOREIGN KEY (item_id) REFERENCES items(id)
-);
-
--- あて先テーブル
-CREATE TABLE addresses
-(
-   id SERIAL PRIMARY KEY,
-   postNum TEXT,
-   prefecture TEXT,
-   municipality TEXT,
-   houseNum TEXT,
-   buildingNameRoomNum TEXT
 );

--- a/src/main/resources/templates/order.html
+++ b/src/main/resources/templates/order.html
@@ -43,7 +43,7 @@
 
 				<div class="one-form-container">
 					<label>郵便番号</label>
-					<input type="text" name="postNum" th:value="${@address.postNum}">
+					<input type="text" name="postNum" th:value="${address.postNum}">
 				</div>
 				<div class="one-form-container">
 					<label>都道府県</label>
@@ -51,22 +51,22 @@
 						<option
 							th:each="prefecture:${prefectureList}"
 							th:value="${prefecture}"
-							th:selected="${@address.isPrefectureSet(prefecture)}">
+							th:selected="${address.isPrefectureSet(prefecture)}">
 							[[${prefecture}]]
 						</option>
 					</select>
 				</div>
 				<div class="one-form-container">
 					<label>市区町村</label>
-					<input type="text" name="municipality" th:value="${@address.municipality}">
+					<input type="text" name="municipality" th:value="${address.municipality}">
 				</div>
 				<div class="one-form-container">
 					<label>番地</label>
-					<input type="text" name="houseNum" th:value="${@address.houseNum}">
+					<input type="text" name="houseNum" th:value="${address.houseNum}">
 				</div>
 				<div class="one-form-container">
 					<label>建物名・部屋番号</label>
-					<input type="text" name="buildingNameRoomNum" th:value="${@address.buildingNameRoomNum}">
+					<input type="text" name="buildingNameRoomNum" th:value="${address.buildingNameRoomNum}">
 				</div>
 
 				<div class="order-buttons">

--- a/src/main/resources/templates/orderConfirm.html
+++ b/src/main/resources/templates/orderConfirm.html
@@ -18,6 +18,11 @@
 			</div>
 
 			<form action="/order"  method="post">
+				<input type="hidden" name="postNum" th:value="${confirmedAddress.postNum}">
+				<input type="hidden" name="prefecture" th:value="${confirmedAddress.prefecture}">
+				<input type="hidden" name="municipality" th:value="${confirmedAddress.municipality}">
+				<input type="hidden" name="houseNum" th:value="${confirmedAddress.houseNum}">
+				<input type="hidden" name="buildingNameRoomNum" th:value="${confirmedAddress.buildingNameRoomNum}">
 				<button>この内容で注文</button>
 			</form>
 
@@ -25,23 +30,23 @@
 			<div class="input-form">
 				<div>
 					<spqn>郵便番号：</spqn>
-					[[${@address.postNum}]]
+					[[${confirmedAddress.postNum}]]
 				</div>
 				<div>
 					<spqn>都道府県：</spqn>
-					[[${@address.prefecture}]]
+					[[${confirmedAddress.prefecture}]]
 				</div>
 				<div>
 					<spqn>市区町村：</spqn>
-					[[${@address.municipality}]]
+					[[${confirmedAddress.municipality}]]
 				</div>
 				<div>
 					<spqn>番地：</spqn>
-					[[${@address.houseNum}]]
+					[[${confirmedAddress.houseNum}]]
 				</div>
 				<div>
 					<spqn>建物名・部屋番号：</spqn>
-					[[${@address.buildingNameRoomNum}]]
+					[[${confirmedAddress.buildingNameRoomNum}]]
 				</div>
 			</div>
 


### PR DESCRIPTION
### 目的
注文に紐づくあて先情報をDBに保管できるようにする

### 修正内容
 - あて先テーブルの作成
 - あて先テーブルのモデル（Entity）の作成、あて先の入力値を格納していたセッションのモデルの削除
 - 注文とあて先を紐づけるためのカラムを注文テーブルに追加
 - DBへの登録処理の追加

### 暫定的な仕様
 - あて先の入力値はセッションではなく単純にパラメータとして受け渡すように変更
### 今後要検討
 - 入力値のデータの受け渡し方はセキュリティ上どの方法が最適なのか

### 手順
1. 商品をカートに追加し、カート画面から「注文画面に進む」を押下
2. 注文画面にてあて先入力フォームが表示されていることを確認し、「建物名・部屋番号」以外のすべての項目を入力し、「注文内容を確認する」を押下
3. 注文確認画面にて、2で入力した値が表示されていることを確認し、「この内容で注文」を押下
4. 注文完了画面が表示される
5. ローカルのDBで、あて先テーブルのレコードが追加されていること、注文テーブルのあて先IDがそれに紐づいていることを確認

### 確認済み
 - ユーザーストーリーの更新
     - タスク番号6, 7, 8のパラメータと内容を変更
     - パラメータに関しては今回の修正で一つのオブジェクトにまとまっているため
 - DB設計の更新
     - addressesテーブルを追加
     - orderesテーブルに`address_id`を追加

### 関連しているタスク
 - #34 
 - #17 