### PR TITLE
【実装】【追加】アカウントのメールアドレスをユニークキーにする #27

### DIFF
--- a/src/main/java/com/example/demo/entity/Account.java
+++ b/src/main/java/com/example/demo/entity/Account.java
@@ -1,5 +1,6 @@
 package com.example.demo.entity;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -15,6 +16,7 @@ public class Account {
 
 	private String name; // 名前
 
+	@Column(unique = true)
 	private String email; // メールアドレス
 
 	private String password; // パスワード

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -28,7 +28,7 @@ CREATE TABLE accounts
 (
    id SERIAL PRIMARY KEY,
    name TEXT,
-   email TEXT,
+   email TEXT UNIQUE,
    password TEXT
 );
 


### PR DESCRIPTION
### 目的
メアドのカラムをユニーク制約にする

### 修正内容
 - accountsテーブルのemailにUNIQUE制約を付与
 - AccountのEntityにUNIQUE制約のアノテーションを付与（明示的にわかりやすくするため）

### 手順
1. プロジェクトを実行し、ローカルのpostgresqlでaccountsのemailにユニーク制約が付与されていることを確認
ー＞ターミナルから実行する場合は``\d accounts``で、pgadmin4で確認する場合は CREATE Scriptを確認
1. アカウントの新規登録画面にてすでに登録されているメアドを用いて登録ボタンを押すと、はじかれることを確認

### 確認済み
 - DB設計の更新
     - accountsテーブルのemailにUNIQUE制約を追加

### 関連しているタスク
 - #7  