### PR TITLE
【実装】【追加】【管理】注文履歴一覧、詳細表示 #20

### DIFF
--- a/src/main/java/com/example/demo/controller/AdminController.java
+++ b/src/main/java/com/example/demo/controller/AdminController.java
@@ -1,0 +1,14 @@
+package com.example.demo.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AdminController {
+	// 管理画面TOPを表示
+	@GetMapping("/admin")
+	public String index() {
+
+		return "adminTop";
+	}
+}

--- a/src/main/java/com/example/demo/controller/OrderController.java
+++ b/src/main/java/com/example/demo/controller/OrderController.java
@@ -17,11 +17,13 @@ import com.example.demo.entity.Address;
 import com.example.demo.entity.Item;
 import com.example.demo.entity.Order;
 import com.example.demo.entity.OrderDetail;
+import com.example.demo.entity.VOrderHistory;
 import com.example.demo.model.Cart;
 import com.example.demo.model.LoginUser;
 import com.example.demo.repository.AddressRepository;
 import com.example.demo.repository.OrderDetailRepository;
 import com.example.demo.repository.OrderRepository;
+import com.example.demo.repository.VOrderRepository;
 
 @Controller
 public class OrderController {
@@ -37,6 +39,9 @@ public class OrderController {
 
 	@Autowired
 	OrderRepository orderRepository;
+
+	@Autowired
+	VOrderRepository vOrderRepository;
 
 	@Autowired
 	OrderDetailRepository orderDetailRepository;
@@ -124,5 +129,16 @@ public class OrderController {
 		model.addAttribute("orderId", savedOrder.getId());
 
 		return "ordered";
+	}
+
+	// （管理）注文履歴一覧画面表示
+	@GetMapping("/admin/order/histories")
+	public String histories(Model model) {
+
+		//	全ユーザーの注文履歴を取得し、画面に渡す
+		List<VOrderHistory> orderList = vOrderRepository.findAll();
+		model.addAttribute("orderList", orderList);
+
+		return "histories";
 	}
 }

--- a/src/main/java/com/example/demo/controller/OrderController.java
+++ b/src/main/java/com/example/demo/controller/OrderController.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -18,12 +19,14 @@ import com.example.demo.entity.Item;
 import com.example.demo.entity.Order;
 import com.example.demo.entity.OrderDetail;
 import com.example.demo.entity.VOrderHistory;
+import com.example.demo.entity.VOrderHistoryDetail;
 import com.example.demo.model.Cart;
 import com.example.demo.model.LoginUser;
 import com.example.demo.repository.AddressRepository;
 import com.example.demo.repository.OrderDetailRepository;
 import com.example.demo.repository.OrderRepository;
-import com.example.demo.repository.VOrderRepository;
+import com.example.demo.repository.VOrderHistoryDetailRepository;
+import com.example.demo.repository.VOrderHistoryRepository;
 
 @Controller
 public class OrderController {
@@ -41,10 +44,13 @@ public class OrderController {
 	OrderRepository orderRepository;
 
 	@Autowired
-	VOrderRepository vOrderRepository;
+	OrderDetailRepository orderDetailRepository;
 
 	@Autowired
-	OrderDetailRepository orderDetailRepository;
+	VOrderHistoryRepository vOrderHistoryRepository;
+
+	@Autowired
+	VOrderHistoryDetailRepository vOrderHistoryDetailRepository;
 
 	// 注文画面表示
 	@GetMapping("/order")
@@ -136,9 +142,26 @@ public class OrderController {
 	public String histories(Model model) {
 
 		//	全ユーザーの注文履歴を取得し、画面に渡す
-		List<VOrderHistory> orderList = vOrderRepository.findAll();
+		List<VOrderHistory> orderList = vOrderHistoryRepository.findAll();
 		model.addAttribute("orderList", orderList);
 
 		return "histories";
+	}
+
+	// （管理）注文履歴詳細画面表示
+	@GetMapping("/admin/order/histories/{orderId}")
+	public String showHistory(
+			@PathVariable("orderId") Integer orderId,
+			Model model) {
+
+		//	１，指定された注文履歴の大まかな情報を取得し、画面に渡す
+		VOrderHistory orderInfo = vOrderHistoryRepository.findById(orderId).get();
+		model.addAttribute("orderInfo", orderInfo);
+
+		//	２，指定された注文履歴の詳細情報を取得し、画面に渡す
+		List<VOrderHistoryDetail> orderHistoryDetailList = vOrderHistoryDetailRepository.findByOrderId(orderId);
+		model.addAttribute("orderHistoryDetailList", orderHistoryDetailList);
+
+		return "showHistory";
 	}
 }

--- a/src/main/java/com/example/demo/entity/VOrderHistory.java
+++ b/src/main/java/com/example/demo/entity/VOrderHistory.java
@@ -24,6 +24,18 @@ public class VOrderHistory {
 	@Column(name = "total_price")
 	private Integer totalPrice; // 合計金額
 
+	@Column(name = "post_num")
+	private String postNum; // 郵便番号
+
+	private String prefecture; // 都道府県
+	private String municipality; // 市区町村
+
+	@Column(name = "house_num")
+	private String houseNum; // 番地
+
+	@Column(name = "building_name_room_num")
+	private String buildingNameRoomNum; // 建物名・部屋番号
+
 	public Integer getId() {
 		return id;
 	}
@@ -38,5 +50,25 @@ public class VOrderHistory {
 
 	public Integer getTotalPrice() {
 		return totalPrice;
+	}
+
+	public String getPostNum() {
+		return postNum;
+	}
+
+	public String getPrefecture() {
+		return prefecture;
+	}
+
+	public String getMunicipality() {
+		return municipality;
+	}
+
+	public String getHouseNum() {
+		return houseNum;
+	}
+
+	public String getBuildingNameRoomNum() {
+		return buildingNameRoomNum;
 	}
 }

--- a/src/main/java/com/example/demo/entity/VOrderHistory.java
+++ b/src/main/java/com/example/demo/entity/VOrderHistory.java
@@ -1,0 +1,42 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+// 注文履歴表示用ビュー
+@Entity
+@Table(name = "v_order_histories")
+public class VOrderHistory {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id; // 注文ID
+
+	@Column(name = "acoount_name")
+	private String acoountName; // アカウント名
+
+	@Column(name = "ordered_datetime")
+	private String orderedDatetime; // 注文日時
+
+	@Column(name = "total_price")
+	private Integer totalPrice; // 合計金額
+
+	public Integer getId() {
+		return id;
+	}
+
+	public String getAcoountName() {
+		return acoountName;
+	}
+
+	public String getOrderedDatetime() {
+		return orderedDatetime;
+	}
+
+	public Integer getTotalPrice() {
+		return totalPrice;
+	}
+}

--- a/src/main/java/com/example/demo/entity/VOrderHistoryDetail.java
+++ b/src/main/java/com/example/demo/entity/VOrderHistoryDetail.java
@@ -1,0 +1,40 @@
+package com.example.demo.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+// 注文履歴詳細表示用ビュー
+@Entity
+@Table(name = "v_order_history_details")
+public class VOrderHistoryDetail {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id; // 注文詳細ID
+
+	@Column(name = "order_id")
+	private Integer orderId; // 注文ID
+
+	@Column(name = "item_name")
+	private String itemName; // 商品名
+
+	@Column(name = "item_price")
+	private Integer itemPrice; // 商品価格
+
+	private Integer quantity; // 数量
+
+	public String getItemName() {
+		return itemName;
+	}
+
+	public Integer getItemPrice() {
+		return itemPrice;
+	}
+
+	public Integer getQuantity() {
+		return quantity;
+	}
+}

--- a/src/main/java/com/example/demo/repository/VOrderHistoryDetailRepository.java
+++ b/src/main/java/com/example/demo/repository/VOrderHistoryDetailRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.demo.entity.VOrderHistoryDetail;
+
+public interface VOrderHistoryDetailRepository extends JpaRepository<VOrderHistoryDetail, Integer> {
+	// SELECT * FROM v_order_history_details WHERE order_id = ?
+	List<VOrderHistoryDetail> findByOrderId(Integer orderId);
+}

--- a/src/main/java/com/example/demo/repository/VOrderHistoryRepository.java
+++ b/src/main/java/com/example/demo/repository/VOrderHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.example.demo.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.demo.entity.VOrderHistory;
+
+public interface VOrderHistoryRepository extends JpaRepository<VOrderHistory, Integer> {
+	// SELECT * FROM v_order_histories WHERE id = ?
+	Optional<VOrderHistory> findById(Integer orderId);
+}

--- a/src/main/java/com/example/demo/repository/VOrderRepository.java
+++ b/src/main/java/com/example/demo/repository/VOrderRepository.java
@@ -1,8 +1,0 @@
-package com.example.demo.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.example.demo.entity.VOrderHistory;
-
-public interface VOrderRepository extends JpaRepository<VOrderHistory, Integer> {
-}

--- a/src/main/java/com/example/demo/repository/VOrderRepository.java
+++ b/src/main/java/com/example/demo/repository/VOrderRepository.java
@@ -1,0 +1,8 @@
+package com.example.demo.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.demo.entity.VOrderHistory;
+
+public interface VOrderRepository extends JpaRepository<VOrderHistory, Integer> {
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -16,3 +16,15 @@ INSERT INTO items(category_id, name, price, description) VALUES(3, 'ゲーム３
 
 INSERT INTO accounts(name, email, password) VALUES('test1', 'test1@example.com', 'password');
 INSERT INTO accounts(name, email, password) VALUES('test2', 'test2@example.com', 'password');
+
+INSERT INTO addresses(post_num, prefecture, municipality, house_num, building_name_room_num)
+	VALUES ('110-0011', '東京都', '千代田区千代田', '1番1号', '皇居101');
+
+INSERT INTO orders(customer_id, ordered_datetime, total_price, address_id)
+	VALUES (NULL, '2023-07-27 12:00:00.000000', 5000, 1);
+INSERT INTO order_details(order_id, item_id, quantity) VALUES (1, 1, 2);
+
+INSERT INTO orders(customer_id, ordered_datetime, total_price, address_id)
+	VALUES (1, '2023-07-27 15:00:00.000000', 4400, 1);
+INSERT INTO order_details(order_id, item_id, quantity) VALUES (2, 3, 2);
+INSERT INTO order_details(order_id, item_id, quantity) VALUES (2, 4, 1);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,3 +1,6 @@
+-- 各種ビュー削除
+DROP VIEW IF EXISTS v_order_histories;
+
 -- 各種テーブル削除
 DROP TABLE IF EXISTS order_details;
 DROP TABLE IF EXISTS orders;
@@ -65,4 +68,17 @@ CREATE TABLE order_details
    quantity INTEGER,
    FOREIGN KEY (order_id) REFERENCES orders(id),
    FOREIGN KEY (item_id) REFERENCES items(id)
+);
+
+-- 注文履歴一覧ビュー
+CREATE VIEW v_order_histories AS
+(
+   SELECT
+      o.id,
+      COALESCE(a.name, 'ゲスト') AS acoount_name,
+      to_char(o.ordered_datetime, 'YYYY-MM-DD HH24:MI:SS') AS ordered_datetime,
+      o.total_price
+   FROM orders o
+   LEFT JOIN accounts a
+      ON o.customer_id = a.id
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -76,12 +76,19 @@ CREATE VIEW v_order_histories AS
 (
    SELECT
       o.id,
-      COALESCE(a.name, 'ゲスト') AS acoount_name,
+      COALESCE(ac.name, 'ゲスト') AS acoount_name,
       to_char(o.ordered_datetime, 'YYYY-MM-DD HH24:MI:SS') AS ordered_datetime,
-      o.total_price
+      o.total_price,
+      ad.post_num,
+      ad.prefecture,
+      ad.municipality,
+      ad.house_num,
+      ad.building_name_room_num
    FROM orders o
-   LEFT JOIN accounts a
-      ON o.customer_id = a.id
+   LEFT JOIN accounts ac
+      ON o.customer_id = ac.id
+   JOIN addresses ad
+      ON o.address_id = ad.id
 );
 
 -- 注文履歴詳細ビュー

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,5 @@
 -- 各種ビュー削除
+DROP VIEW IF EXISTS v_order_history_details;
 DROP VIEW IF EXISTS v_order_histories;
 
 -- 各種テーブル削除
@@ -81,4 +82,18 @@ CREATE VIEW v_order_histories AS
    FROM orders o
    LEFT JOIN accounts a
       ON o.customer_id = a.id
+);
+
+-- 注文履歴詳細ビュー
+CREATE VIEW v_order_history_details AS
+(
+   SELECT
+      od.id,
+      od.order_id,
+      i.name AS item_name,
+      i.price AS item_price,
+      od.quantity
+   FROM order_details od
+   JOIN items i
+      ON od.item_id = i.id
 );

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -174,7 +174,7 @@ footer  {
 }
 
 /* 管理TOP */
-.admin-function-list  {
+.admin-function-list {
 	display: flex;
     justify-content: center;
 }
@@ -186,4 +186,12 @@ footer  {
     height: 100px;
     padding: 20px;
     text-decoration: none;
+}
+
+/* 管理注文履歴一覧 */
+.history-container {
+	background-color: rgb(255, 255, 255);
+    display: flex;
+    justify-content: center;
+    width: 80%;
 }

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -172,3 +172,18 @@ main {
 footer  {
 	text-align: center;
 }
+
+/* 管理TOP */
+.admin-function-list  {
+	display: flex;
+    justify-content: center;
+}
+.round {
+    align-items: center;
+	background-color: white;
+    border-radius: 50%;
+    display: flex;
+    height: 100px;
+    padding: 20px;
+    text-decoration: none;
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -19,11 +19,7 @@ header {
     font-weight: bold;
 	text-decoration: none;
 }
-.header-menu-login {
-	text-align: center;
-	width: 25%;
-}
-.header-menu-cart {
+.header-menu-element {
 	text-align: center;
 	width: 25%;
 }

--- a/src/main/resources/templates/adminTop.html
+++ b/src/main/resources/templates/adminTop.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>管理TOP</title>
+<link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
+</head>
+<body>
+	<header th:replace="header"></header>
+
+	<hr>
+
+	<main>
+		<div class="main-container">
+			<!-- 機能一覧 -->
+			<div class="admin-function-list">
+				<a href="/admin/order/histories" class="round">注文履歴一覧</a>
+			</div>
+		</div>
+	</main>
+
+	<hr>
+
+	<footer th:replace="footer"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -3,7 +3,10 @@
 		<div class="header-menu-title">
 			<a href="/items">使いやすいショッピングサイト</a>
 		</div>
-		<div class="header-menu-login">
+		<div class="header-menu-element">
+			<a href="/admin">管理画面</a>
+		</div>
+		<div class="header-menu-element">
 			<th:block th:if="${@loginUser.getName() != null}">
 				[[${@loginUser.getName()}]]
 				<a href="/logout">ログアウト</a>
@@ -12,7 +15,7 @@
 				<a href="/login">新規登録 &#047; ログイン</a>
 			</th:block>
 		</div>
-		<div class="header-menu-cart">
+		<div class="header-menu-element">
 			<a href="/cart">&#128722;カート</a>
 		</div>
 	</nav>

--- a/src/main/resources/templates/histories.html
+++ b/src/main/resources/templates/histories.html
@@ -17,6 +17,7 @@
 					<p>アカウント名：[[${order.acoountName}]]</p>
 					<p>注文日時：[[${order.orderedDatetime}]]</p>
 					<p>合計金額：[[${order.totalPrice}]]</p>
+					<p>あて先：[[${order.prefecture}]]</p>
 					<div class="column-center">
 						<a th:href="'/admin/order/histories/' + ${order.id}">
 							詳細

--- a/src/main/resources/templates/histories.html
+++ b/src/main/resources/templates/histories.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>商品一覧</title>
+<link rel="stylesheet" type="text/css" th:href="@{/css/style.css}">
+</head>
+<body>
+	<header th:replace="header"></header>
+
+	<hr>
+
+	<main>
+		<div class="main-container column-center">
+			<div th:each="order:${orderList}" class="history-container">
+				<div>
+					<p>アカウント名：[[${order.acoountName}]]</p>
+					<p>注文日時：[[${order.orderedDatetime}]]</p>
+					<p>合計金額：[[${order.totalPrice}]]</p>
+					<div class="column-center">
+						<a th:href="'/admin/order/histories/' + ${order.id}">
+							詳細
+						</a>
+					</div>
+				</div>
+			</div>
+		</div>
+	</main>
+
+	<hr>
+
+	<footer th:replace="footer"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/showHistory.html
+++ b/src/main/resources/templates/showHistory.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+<meta charset="UTF-8">
+<title>注文内容確認画面</title>
+<link rel="stylesheet" type="text/css" href="/css/style.css">
+</head>
+<body>
+	<header th:replace="header"></header>
+
+	<hr>
+
+	<main>
+		<div class="main-container column-center">
+			<div class="history-container">
+				<div>
+					<p>アカウント名：[[${orderInfo.acoountName}]]</p>
+					<p>注文日時：[[${orderInfo.orderedDatetime}]]</p>
+					<p>合計金額：[[${orderInfo.totalPrice}]]</p>
+				</div>
+			</div>
+
+			<!-- あて先表示 -->
+
+			<!-- 商品履歴詳細 -->
+			<div class="column-center">
+				<div th:each="orderHistoryDetail:${orderHistoryDetailList}" class="item-container column-center cart-item">
+					<div class="img-title-container">
+						<img th:src="@{/img/sample_test1.jpg}">
+						<span th:text="${orderHistoryDetail.itemName}"></span>
+					</div>
+					<div>
+						<span>価格</span>
+						<span th:text="${orderHistoryDetail.itemPrice}"></span>
+					</div>
+					<div>
+						<span>数量</span>
+						<span th:text="${orderHistoryDetail.quantity}"></span>
+					</div>
+				</div>
+			</div>
+		</div>
+	</main>
+
+	<hr>
+
+	<footer th:replace="footer"></footer>
+</body>
+</html>

--- a/src/main/resources/templates/showHistory.html
+++ b/src/main/resources/templates/showHistory.html
@@ -24,6 +24,29 @@
 			</div>
 
 			<!-- あて先表示 -->
+			<div class="input-form">
+				<strong>あて先</strong>
+				<div>
+					<spqn>郵便番号：</spqn>
+					[[${orderInfo.postNum}]]
+				</div>
+				<div>
+					<spqn>都道府県：</spqn>
+					[[${orderInfo.prefecture}]]
+				</div>
+				<div>
+					<spqn>市区町村：</spqn>
+					[[${orderInfo.municipality}]]
+				</div>
+				<div>
+					<spqn>番地：</spqn>
+					[[${orderInfo.houseNum}]]
+				</div>
+				<div>
+					<spqn>建物名・部屋番号：</spqn>
+					[[${orderInfo.buildingNameRoomNum}]]
+				</div>
+			</div>
 
 			<!-- 商品履歴詳細 -->
 			<div class="column-center">

--- a/src/main/resources/templates/showHistory.html
+++ b/src/main/resources/templates/showHistory.html
@@ -12,6 +12,9 @@
 
 	<main>
 		<div class="main-container column-center">
+			<a href="/admin/order/histories">一覧画面に戻る</a>
+
+			<!-- 注文履歴概要 -->
 			<div class="history-container">
 				<div>
 					<p>アカウント名：[[${orderInfo.acoountName}]]</p>


### PR DESCRIPTION
### 目的
全ユーザの注文履歴を閲覧できる管理画面の作成

### 修正内容
 - 管理画面に遷移するボタンを配置
ー＞とりあえずログインユーザー関係なくヘッダーに固定で表示（ログインユーザーによる区別は #41 にて対応予定）
 - 管理画面のTOPページの作成
 - 管理用の注文履歴一覧ページの作成
 - 詳細ページの作成

### デモ手順
1. TOPページのヘッダーの「管理画面」を押下し、管理TOPページに「注文履歴一覧」が表示されていることを確認
1. 「注文履歴一覧」を押下すると、注文履歴の一覧が表示されていることを確認
ー＞表示項目は、アカウント名、注文日時、合計金額、あて先の都道府県、詳細リンク
　　また、ログインしていないユーザーは「ゲスト」と表示されていることを確認
1. それぞれの履歴の詳細リンクを押下すると、それぞれの注文履歴の詳細が表示されることを確認
ー＞表示項目は、アカウント名、注文日時、合計金額、あて先、商品名、金額、商品の画像、数量
　　また、一覧画面に戻るリンクが先頭にあることを確認

※**注意事項**
デモ手順が終わって別のブランチで作業する際には、`schema.sql`の先頭に以下のコードを入力し、保存し1回サーバを再起動してから作業してください。（以下のビューが残っている限り対応するテーブルが削除できないため）
１回再起動できたらもう削除して大丈夫です。
DROP VIEW IF EXISTS v_order_history_details;
DROP VIEW IF EXISTS v_order_histories;

### 確認済み
 - DB設計に、Viewの追加
 - DB設計に、あて先、注文、注文詳細のテストデータの追加
 - ユーザーストーリーに、それぞれのAPIを追加

### 関連しているタスク
 - #41  （新規追加）
 - #10 
 - #21 
 - #22 