### PR TITLE
【実装】【追加】商品一覧の検索 #9

### DIFF
--- a/src/main/java/com/example/demo/controller/ItemController.java
+++ b/src/main/java/com/example/demo/controller/ItemController.java
@@ -75,6 +75,12 @@ public class ItemController {
 
 		model.addAttribute("items", items);
 
+		//	検索条件を保持
+		model.addAttribute("itemName", itemName);
+		model.addAttribute("matchCondition", matchCondition);
+		model.addAttribute("minPrice", minPrice);
+		model.addAttribute("maxPrice", maxPrice);
+
 		return "items";
 	}
 

--- a/src/main/java/com/example/demo/controller/ItemController.java
+++ b/src/main/java/com/example/demo/controller/ItemController.java
@@ -1,6 +1,8 @@
 package com.example.demo.controller;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -74,6 +76,17 @@ public class ItemController {
 		}
 
 		model.addAttribute("items", items);
+
+		//	商品名検索の条件をマップに格納し、画面に渡す
+		Map<String, String> matchConditions = new HashMap<String, String>() {
+			{
+				put("partial", "部分一致");
+				put("all", "完全一致");
+				put("starting", "前方一致");
+				put("ending", "後方一致");
+			}
+		};
+		model.addAttribute("matchConditions", matchConditions);
 
 		//	検索条件を保持
 		model.addAttribute("itemName", itemName);

--- a/src/main/java/com/example/demo/controller/ItemController.java
+++ b/src/main/java/com/example/demo/controller/ItemController.java
@@ -3,6 +3,8 @@ package com.example.demo.controller;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.ExampleMatcher;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,20 +29,56 @@ public class ItemController {
 	@GetMapping("/items")
 	public String index(
 			@RequestParam(value = "categoryId", defaultValue = "") Integer categoryId,
+			@RequestParam(value = "itemName", defaultValue = "") String itemName,
+			@RequestParam(value = "matchCondition", defaultValue = "partial") String matchCondition,
+			@RequestParam(value = "min", defaultValue = "") Integer min,
+			@RequestParam(value = "max", defaultValue = "") Integer max,
 			Model model) {
-		//		全カテゴリーを取得
+		//	全カテゴリーを取得
 		List<Category> categories = categoryRepository.findAll();
 		model.addAttribute("categories", categories);
 
 		List<Item> items = null;
 
-		if (categoryId == null) {
-			//		全商品を取得
-			items = itemRepository.findAll();
-		} else {
-			//		カテゴリーで絞った商品を取得
+		//	カテゴリーが指定されていたら他の検索条件は無視
+		if (categoryId != null) {
+			//	カテゴリーで絞った商品を取得
 			items = itemRepository.findByCategoryId(categoryId);
+		} else {
+			//	文字列検索条件
+			ExampleMatcher matcher = ExampleMatcher.matching().withIgnoreCase(); // 大文字小文字区別なし
+			switch (matchCondition) {
+			//	部分一致
+			case "partial":
+				matcher = matcher.withStringMatcher(ExampleMatcher.StringMatcher.CONTAINING);
+				break;
+			//	完全一致
+			case "all":
+				matcher = matcher.withStringMatcher(ExampleMatcher.StringMatcher.EXACT);
+
+				break;
+			//	前方一致
+			case "starting":
+				matcher = matcher.withStringMatcher(ExampleMatcher.StringMatcher.STARTING);
+				break;
+			//	後方一致
+			case "ending":
+				matcher = matcher.withStringMatcher(ExampleMatcher.StringMatcher.ENDING);
+				break;
+			}
+
+			//	検索条件をもとにQuery by Example用のオブジェクトの作成
+			Item itemSearchCondition = new Item();
+			if (!itemName.equals("")) {
+				//	商品名が入力されていれば条件に追加
+				itemSearchCondition.setName(itemName);
+			}
+
+			//	Query by Exampleの実行
+			Example<Item> example = Example.of(itemSearchCondition, matcher);
+			items = itemRepository.findAll(example);
 		}
+
 		model.addAttribute("items", items);
 
 		return "items";

--- a/src/main/java/com/example/demo/entity/Item.java
+++ b/src/main/java/com/example/demo/entity/Item.java
@@ -48,10 +48,6 @@ public class Item {
 		return name;
 	}
 
-	public void setName(String name) {
-		this.name = name;
-	}
-
 	public Integer getPrice() {
 		return price;
 	}

--- a/src/main/java/com/example/demo/entity/Item.java
+++ b/src/main/java/com/example/demo/entity/Item.java
@@ -48,6 +48,10 @@ public class Item {
 		return name;
 	}
 
+	public void setName(String name) {
+		this.name = name;
+	}
+
 	public Integer getPrice() {
 		return price;
 	}

--- a/src/main/java/com/example/demo/repository/ItemRepository.java
+++ b/src/main/java/com/example/demo/repository/ItemRepository.java
@@ -3,10 +3,22 @@ package com.example.demo.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.demo.entity.Item;
 
 public interface ItemRepository extends JpaRepository<Item, Integer> {
 	// SELECT * FROM items WHERE category_id = ?
 	List<Item> findByCategoryId(Integer categoryId);
+
+	//	商品名、価格の下限・上限をもとにクエリを作成
+	@Query("SELECT i FROM Item i WHERE " +
+			"(:name IS NULL OR i.name ILIKE :name) " +
+			"AND (:minPrice IS NULL OR i.price >= :minPrice) " +
+			"AND (:maxPrice IS NULL OR i.price <= :maxPrice)")
+	List<Item> searchByCriteria(
+			@Param("name") String name,
+			@Param("minPrice") Integer minPrice,
+			@Param("maxPrice") Integer maxPrice);
 }

--- a/src/main/java/com/example/demo/repository/ItemRepository.java
+++ b/src/main/java/com/example/demo/repository/ItemRepository.java
@@ -14,8 +14,8 @@ public interface ItemRepository extends JpaRepository<Item, Integer> {
 
 	//	商品名、価格の下限・上限をもとにクエリを作成
 	@Query("SELECT i FROM Item i WHERE " +
-			"(:name = '' OR i.name ILIKE :name) " +
-			"AND (:minPrice IS NULL OR i.price >= :minPrice) " +
+			"(:name = '' OR i.name ILIKE :name)" +
+			"AND (:minPrice IS NULL OR i.price >= :minPrice)" +
 			"AND (:maxPrice IS NULL OR i.price <= :maxPrice)")
 	List<Item> searchByCriteria(
 			@Param("name") String name,

--- a/src/main/java/com/example/demo/repository/ItemRepository.java
+++ b/src/main/java/com/example/demo/repository/ItemRepository.java
@@ -14,7 +14,7 @@ public interface ItemRepository extends JpaRepository<Item, Integer> {
 
 	//	商品名、価格の下限・上限をもとにクエリを作成
 	@Query("SELECT i FROM Item i WHERE " +
-			"(:name IS NULL OR i.name ILIKE :name) " +
+			"(:name = '' OR i.name ILIKE :name) " +
 			"AND (:minPrice IS NULL OR i.price >= :minPrice) " +
 			"AND (:maxPrice IS NULL OR i.price <= :maxPrice)")
 	List<Item> searchByCriteria(

--- a/src/main/java/com/example/demo/service/SearchService.java
+++ b/src/main/java/com/example/demo/service/SearchService.java
@@ -1,0 +1,47 @@
+package com.example.demo.service;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class SearchService {
+	//	文字列検索用のマッチパターン
+	public static Map<String, String> stringMatchPatterns = new LinkedHashMap<String, String>() {
+		{
+			put("partial", "部分一致");
+			put("all", "完全一致");
+			put("starting", "前方一致");
+			put("ending", "後方一致");
+		}
+	};
+
+	//	マッチパターンに基づき指定された文字列にクエリ用の「％」を付与
+	public static String getValueWithWildcard(String value, String matchPattern) {
+		String valueWithWildcard = value;
+
+		//	指定された文字列が空の場合はそのまま返す
+		if (!valueWithWildcard.equals("")) {
+			switch (matchPattern) {
+			//	完全一致
+			case "all":
+				break;
+			//	部分一致
+			case "partial":
+				valueWithWildcard = '%' + valueWithWildcard + '%';
+				break;
+			//	前方一致
+			case "starting":
+				valueWithWildcard = valueWithWildcard + '%';
+				break;
+			//	後方一致
+			case "ending":
+				valueWithWildcard = '%' + valueWithWildcard;
+				break;
+			}
+		}
+
+		return valueWithWildcard;
+	}
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -2,17 +2,17 @@ INSERT INTO categories(name) VALUES('本');
 INSERT INTO categories(name) VALUES('DVD');
 INSERT INTO categories(name) VALUES('ゲーム');
 
-INSERT INTO items(category_id, name, price, description, file_name) VALUES(1, '本１', 2500, '短い説明です', 'sample_test1.jpg');
-INSERT INTO items(category_id, name, price, description, file_name) VALUES(1, '本２　中間くらいの長さ', 980, '中間くらいの長さの説明です', 'sample_test2.png');
-INSERT INTO items(category_id, name, price, description, file_name) VALUES(1, '本３　結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです', 1200, '結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です', 'sample_test3.jpg');
+INSERT INTO items(category_id, name, price, description, file_name) VALUES(1, '本１aaa', 2500, '短い説明です', 'sample_test1.jpg');
+INSERT INTO items(category_id, name, price, description, file_name) VALUES(1, '本２bbb　中間くらいの長さ', 980, '中間くらいの長さの説明です', 'sample_test2.png');
+INSERT INTO items(category_id, name, price, description, file_name) VALUES(1, '本３ccc　結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです', 1200, '結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です', 'sample_test3.jpg');
 
-INSERT INTO items(category_id, name, price, description, file_name) VALUES(2, 'DVD１', 2000, '短い説明です', 'sample_test1.jpg');
-INSERT INTO items(category_id, name, price, description, file_name) VALUES(2, 'DVD２　中間くらいの長さ', 1000, '中間くらいの長さの説明です', 'sample_test2.png');
-INSERT INTO items(category_id, name, price, description, file_name) VALUES(2, 'DVD３　結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです', 1800, '結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です', 'sample_test3.jpg');
+INSERT INTO items(category_id, name, price, description, file_name) VALUES(2, 'DVD１AAA', 2000, '短い説明です', 'sample_test1.jpg');
+INSERT INTO items(category_id, name, price, description, file_name) VALUES(2, 'DVD２BBB　中間くらいの長さ', 1000, '中間くらいの長さの説明です', 'sample_test2.png');
+INSERT INTO items(category_id, name, price, description, file_name) VALUES(2, 'DVD３CCC　結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです', 1800, '結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です', 'sample_test3.jpg');
 
-INSERT INTO items(category_id, name, price, description, file_name) VALUES(3, 'ゲーム１', 780, '短い説明です', 'sample_test1.jpg');
-INSERT INTO items(category_id, name, price, description, file_name) VALUES(3, 'ゲーム２　中間くらいの長さ', 3400, '中間くらいの長さの説明です', 'sample_test2.png');
-INSERT INTO items(category_id, name, price, description, file_name) VALUES(3, 'ゲーム３　結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです', 2200, '結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です', 'sample_test3.jpg');
+INSERT INTO items(category_id, name, price, description, file_name) VALUES(3, 'ゲーム１aAa', 780, '短い説明です', 'sample_test1.jpg');
+INSERT INTO items(category_id, name, price, description, file_name) VALUES(3, 'ゲーム２BbB　中間くらいの長さ', 3400, '中間くらいの長さの説明です', 'sample_test2.png');
+INSERT INTO items(category_id, name, price, description, file_name) VALUES(3, 'ゲーム３ccC　結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです結構長めのタイトルです', 2200, '結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です結構長めの説明です', 'sample_test3.jpg');
 
 INSERT INTO accounts(name, email, password) VALUES('test1', 'test1@example.com', 'password');
 INSERT INTO accounts(name, email, password) VALUES('test2', 'test2@example.com', 'password');

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -42,6 +42,16 @@ main {
 	flex-flow: column;
 	gap: 20px 0;
 }
+.row-center {
+	/* 縦並び、中央寄せ */
+	display: flex;
+	justify-content: center;
+}
+.row-space-around {
+	/* 縦並び、均等配置と両端に間隔 */
+	display: flex;
+	justify-content: space-around;
+}
 .input-form {
 	/* 入力フォーム */
 	align-items: center;
@@ -71,6 +81,12 @@ main {
 	gap: 50px;
     justify-content: center;
     width: 80%;
+}
+.search-cotainer {
+	align-items: center;
+	display: flex;
+	flex-flow: column;
+	gap: 10px 0;
 }
 .item {
     display: flex;

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -33,11 +33,11 @@
 						</div>
 						<div class="row-space-around">
 							<!--文字列の検索条件-->
-		    				<th:block th:each="mc : ${matchConditions}">
-			    				<input type="radio" name="matchCondition"
-			    					th:value="${mc.key}"
-			    					th:checked="${mc.key == matchCondition}" />
-			    				<label for="${mc.key}">[[${mc.value}]]</label>
+		    				<th:block th:each="mp : ${matchPatterns}">
+			    				<input type="radio" name="matchPattern"
+			    					th:value="${mp.key}"
+			    					th:checked="${mp.key == matchPattern}" />
+			    				<label for="${mp.key}">[[${mc.value}]]</label>
 							</th:block>
 						</div>
 					</div>

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -35,9 +35,9 @@
 							<!--文字列の検索条件-->
 		    				<th:block th:each="mp : ${matchPatterns}">
 			    				<input type="radio" name="matchPattern"
-			    					th:value="${mp.key}"
-			    					th:checked="${mp.key == matchPattern}" />
-			    				<label for="${mp.key}">[[${mc.value}]]</label>
+			    					th:value="${mp.getKey()}"
+			    					th:checked="${mp.getKey() == matchPattern}" />
+			    				<label for="${mp.getKey()}">[[${mp.getValue()}]]</label>
 							</th:block>
 						</div>
 					</div>

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -22,6 +22,35 @@
 					<span th:text="${category.name}"></span>
 				</a>
 			</nav>
+
+			<!--　検索項目　-->
+			<form action="/items" method="get">
+				<div class="column-center">
+					<div>
+						<div class="row-center">
+							<span>商品名：</span>
+							<input type="text" name="itemName">
+						</div>
+						<div class="row-space-around">
+							<input type="radio" name="matchCondition" value="partial" checked />
+		    				<label for="partial">部分一致</label>
+							<input type="radio" name="matchCondition" value="all" />
+		    				<label for="all">完全一致</label>
+							<input type="radio" name="matchCondition" value="start" />
+		    				<label for="start">前方一致</label>
+							<input type="radio" name="matchCondition" value="end" />
+		    				<label for="end">後方一致</label>
+						</div>
+					</div>
+					<div class="row-space-around">
+						<span>価格：</span>
+						<input type="number" name="min" placeholder="下限なし">
+						<span>～</span>
+						<input type="number" name="max" placeholder="上限なし">
+					</div>
+					<button>検索</button>
+				</div>
+			</form>
 	
 			<div th:each="item:${items}" class="item-container">
 				<form action="/cart/add" method="post">

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -32,14 +32,13 @@
 							<input type="text" name="itemName" th:value="${itemName}">
 						</div>
 						<div class="row-space-around">
-							<input type="radio" name="matchCondition" value="partial" th:checked="${matchCondition == 'partial'}" />
-		    				<label for="partial">部分一致</label>
-							<input type="radio" name="matchCondition" value="all" th:checked="${matchCondition == 'all'}" />
-		    				<label for="all">完全一致</label>
-							<input type="radio" name="matchCondition" value="starting" th:checked="${matchCondition == 'starting'}" />
-		    				<label for="start">前方一致</label>
-							<input type="radio" name="matchCondition" value="ending" th:checked="${matchCondition == 'ending'}" />
-		    				<label for="end">後方一致</label>
+							<!--文字列の検索条件-->
+		    				<th:block th:each="mc : ${matchConditions}">
+			    				<input type="radio" name="matchCondition"
+			    					th:value="${mc.key}"
+			    					th:checked="${mc.key == matchCondition}" />
+			    				<label for="${mc.key}">[[${mc.value}]]</label>
+							</th:block>
 						</div>
 					</div>
 					<div class="row-space-around">

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -44,9 +44,9 @@
 					</div>
 					<div class="row-space-around">
 						<span>価格：</span>
-						<input type="number" name="min" placeholder="下限なし">
+						<input type="number" name="minPrice" placeholder="下限なし">
 						<span>～</span>
-						<input type="number" name="max" placeholder="上限なし">
+						<input type="number" name="maxPrice" placeholder="上限なし">
 					</div>
 					<button>検索</button>
 				</div>

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -29,24 +29,24 @@
 					<div>
 						<div class="row-center">
 							<span>商品名：</span>
-							<input type="text" name="itemName">
+							<input type="text" name="itemName" th:value="${itemName}">
 						</div>
 						<div class="row-space-around">
-							<input type="radio" name="matchCondition" value="partial" checked />
+							<input type="radio" name="matchCondition" value="partial" th:checked="${matchCondition == 'partial'}" />
 		    				<label for="partial">部分一致</label>
-							<input type="radio" name="matchCondition" value="all" />
+							<input type="radio" name="matchCondition" value="all" th:checked="${matchCondition == 'all'}" />
 		    				<label for="all">完全一致</label>
-							<input type="radio" name="matchCondition" value="starting" />
+							<input type="radio" name="matchCondition" value="starting" th:checked="${matchCondition == 'starting'}" />
 		    				<label for="start">前方一致</label>
-							<input type="radio" name="matchCondition" value="ending" />
+							<input type="radio" name="matchCondition" value="ending" th:checked="${matchCondition == 'ending'}" />
 		    				<label for="end">後方一致</label>
 						</div>
 					</div>
 					<div class="row-space-around">
 						<span>価格：</span>
-						<input type="number" name="minPrice" placeholder="下限なし">
+						<input type="number" name="minPrice" placeholder="下限なし" th:value="${minPrice}">
 						<span>～</span>
-						<input type="number" name="maxPrice" placeholder="上限なし">
+						<input type="number" name="maxPrice" placeholder="上限なし" th:value="${maxPrice}">
 					</div>
 					<button>検索</button>
 				</div>

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -36,7 +36,7 @@
 		    				<th:block th:each="mp : ${matchPatterns}">
 			    				<input type="radio" name="matchPattern"
 			    					th:value="${mp.getKey()}"
-			    					th:checked="${mp.getKey() == matchPattern}" />
+			    					th:checked="${mp.getKey().equals(matchPattern)}" />
 			    				<label for="${mp.getKey()}">[[${mp.getValue()}]]</label>
 							</th:block>
 						</div>

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -36,9 +36,9 @@
 		    				<label for="partial">部分一致</label>
 							<input type="radio" name="matchCondition" value="all" />
 		    				<label for="all">完全一致</label>
-							<input type="radio" name="matchCondition" value="start" />
+							<input type="radio" name="matchCondition" value="starting" />
 		    				<label for="start">前方一致</label>
-							<input type="radio" name="matchCondition" value="end" />
+							<input type="radio" name="matchCondition" value="ending" />
 		    				<label for="end">後方一致</label>
 						</div>
 					</div>


### PR DESCRIPTION
### 目的
商品一覧画面で商品名、価格の検索ができるようにする

### 修正内容
 - 商品名の検索の追加（部分一致、前方一致、後方一致、完全一致）※一旦大文字小文字の区別は無しで（ILIKE 条件）
 - 価格の検索の追加（○○円　～　○○円等）
 - 検索後の検索条件は埋めたままにするように修正

### ほか仕様
 - 商品名と価格どちらも指定した場合は「かつ」として検索をする
 - カテゴリと検索条件は「かつ」として扱っていない
 ー＞カテゴリは指定した瞬間に検索条件はまっさらになるし、検索を押すとカテゴリの指定は外れてしまう

### デモ手順
1. 一覧画面にて商品名、価格それぞれを指定して検索をしたときに、正常な値が取得されてくることを確認

### 確認済み
 - ユーザーストーリーの一覧画面のパラメータの修正

### 関連しているタスク
 - #52 
 - #53 