### PR TITLE
【バグ】ユーザーの新規登録時にロールがnullになっている #57

### DIFF
--- a/src/main/java/com/example/demo/entity/Account.java
+++ b/src/main/java/com/example/demo/entity/Account.java
@@ -21,7 +21,7 @@ public class Account {
 
 	private String password; // パスワード
 
-	private String role; // ロール
+	private String role = "general"; // ロール
 
 	public Account() {
 	}


### PR DESCRIPTION
### 修正内容
 - アカウントのインスタンス生成時にデフォルトでroleに「general」が格納されるように修正

### デモ手順
1. アカウントの新規登録をする
2. 実際にDB内のレコードを確認し、登録したアカウントのroleに「general」が入っていることを確認