### PR TITLE
【デザイン】【追加】商品一覧ページ以外のレイアウトの修正 ver2-2 #60

### DIFF
--- a/src/main/java/com/example/demo/controller/AccountController.java
+++ b/src/main/java/com/example/demo/controller/AccountController.java
@@ -56,7 +56,7 @@ public class AccountController {
 		if (email.length() == 0 || password.length() == 0) {
 			//	入力値はそのままにし、エラーメッセージをリダイレクト先に渡す
 			redirectAttributes.addAttribute("email", email);
-			redirectAttributes.addAttribute("errMes", "どちらも必須項目です。");
+			redirectAttributes.addAttribute("errMes", "未入力の項目があります。");
 
 			return "redirect:/login";
 		}
@@ -133,7 +133,7 @@ public class AccountController {
 			//	入力値はそのままにし、エラーメッセージをリダイレクト先に渡す
 			redirectAttributes.addAttribute("name", name);
 			redirectAttributes.addAttribute("email", email);
-			redirectAttributes.addAttribute("errMes", "全て必須項目です。");
+			redirectAttributes.addAttribute("errMes", "未入力の項目があります。");
 
 			return "redirect:/register";
 		}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -35,6 +35,7 @@ body {
 	flex-direction: column;
 	margin: 0;
 	min-height: 100vh;
+	font-family: cursive;
 }
 
 a {
@@ -376,8 +377,9 @@ input-form img {
 
 .top-banner img {
 	height: 100%;
-	width: 100%;
 	object-fit: cover;
+	opacity: 50%;
+	width: 100%;
 }
 
 .top-banner .cover {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -71,6 +71,10 @@ a:hover {
 	opacity: 70%;
 }
 
+form {
+	width: 100%;
+}
+
 button {
 	width: 100%;
 	border: 1px solid var(--main-color);
@@ -294,6 +298,11 @@ input-form img {
 	gap: 10px;
 	grid-template-columns: 50% 50%;
 }
+.grid-1-4 {
+	display: grid;
+	gap: 10px;
+	grid-template-columns: 20% 80%;
+}
 
 .font-emphasize {
 	font-weight: bold;
@@ -322,6 +331,13 @@ input-form img {
 	margin-top: 50px;
 }
 
+/* 必須マーク(右横) */
+.required::after {
+    color: red;
+	content: "※必須";
+    margin-left: 5px;
+}
+
 /* 点線 */
 .dots-line {
 	border-top: 3px dotted black;
@@ -331,32 +347,24 @@ input-form img {
 
 /* 一つ一つの商品の箱 */
 .item-container {
-	align-items: center;
-	display: flex;
+    display: grid;
 	gap: 25px;
-	margin-top: 50px;
+    grid-template-columns: 60% 40%;;
+	grid-template-rows: 40vh;
+	margin-top: 25px;
 	width: 100%;
 }
 
 .item-container img {
-	max-height: 80%;
-	object-fit: fill;
-	width: 50%;
-}
-
-.item-container form {
 	height: 100%;
+	object-fit: fill;
 	width: 100%;
 }
 
 .item-container-right {
-	width: 50%;
-}
-
-/* ログイン・新規登録 */
-.auth-container {
-	margin-top: 50px;
-	height: 40vh;
+	display: flex;
+    flex-flow: column;
+    justify-content: space-evenly;
 }
 
 /* 商品一覧（TOP） */
@@ -460,7 +468,8 @@ input-form img {
 
 /* 商品詳細 */
 .show-item {
-	height: 70vh;
+	grid-template-rows: 60vh;
+	width: 80%;
 }
 
 /* 注文 */
@@ -471,21 +480,11 @@ input-form img {
     grid-template-columns: 1fr 1fr;
 }
 
-/* 注文確認 */
-.order-confirm-container {
-    margin-top: 50px;
-}
-
-.total-price-item {
-	gap: 0;
-}
-
 /* 注文完了 */
 .ordered-item {
     display: flex;
     justify-content: center;
 	height: 30vh;
-	margin-top: 50px;
 }
 
 /* フッター */

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -234,10 +234,11 @@ main {
 
 /* インライン要素の配置をそろえる */
 .inline-center {
-	text-align: center;	
+	text-align: center;
 }
+
 .inline-right {
-    text-align: right;
+	text-align: right;
 }
 
 /* 入力フォーム */
@@ -245,7 +246,7 @@ main {
 	align-items: center;
 	background-color: var(--background-color-with-opacity);
 	border-radius: 10px;
-    box-sizing: border-box;
+	box-sizing: border-box;
 	display: flex;
 	flex-flow: column;
 	gap: 20px 0;
@@ -275,8 +276,8 @@ input-form img {
 }
 
 .input-form img {
-    height: 300px;
-    object-fit: fill;
+	height: 300px;
+	object-fit: fill;
 	width: 400px;
 }
 
@@ -284,7 +285,7 @@ input-form img {
 .output-form {
 	background-color: var(--background-color-with-opacity);
 	border-radius: 10px;
-    box-sizing: border-box;
+	box-sizing: border-box;
 	display: flex;
 	flex-flow: column;
 	gap: 10px 0;
@@ -299,6 +300,7 @@ input-form img {
 	gap: 10px;
 	grid-template-columns: 50% 50%;
 }
+
 .grid-1-4 {
 	display: grid;
 	gap: 10px;
@@ -334,9 +336,9 @@ input-form img {
 
 /* 必須マーク(右横) */
 .required::after {
-    color: red;
+	color: red;
 	content: "※必須";
-    margin-left: 5px;
+	margin-left: 5px;
 }
 
 /* 点線 */
@@ -348,9 +350,9 @@ input-form img {
 
 /* 一つ一つの商品の箱 */
 .item-container {
-    display: grid;
+	display: grid;
 	gap: 25px;
-    grid-template-columns: 60% 40%;;
+	grid-template-columns: 60% 40%;
 	grid-template-rows: 40vh;
 	margin-top: 25px;
 	width: 100%;
@@ -364,8 +366,8 @@ input-form img {
 
 .item-container-right {
 	display: flex;
-    flex-flow: column;
-    justify-content: space-evenly;
+	flex-flow: column;
+	justify-content: space-evenly;
 }
 
 /* 商品一覧（TOP） */
@@ -410,7 +412,7 @@ input-form img {
 }
 
 .search-container {
-  margin: 50px auto 0;
+	margin: 50px auto 0;
 	width: 70%;
 }
 
@@ -428,8 +430,8 @@ input-form img {
 	display: flex;
 	flex-direction: column;
 	height: 65vh;
-    margin: 10px;
-    max-width: 100%;
+	margin: 10px;
+	max-width: 100%;
 	text-decoration: none;
 }
 
@@ -452,7 +454,7 @@ input-form img {
 	font-size: 20px;
 	overflow: hidden;
 	text-overflow: ellipsis;
-    white-space: nowrap;
+	white-space: nowrap;
 }
 
 .item-price {
@@ -478,14 +480,14 @@ input-form img {
 /* ボタン横並び */
 .row-buttons {
 	display: grid;
-    gap: 25px;
-    grid-template-columns: 1fr 1fr;
+	gap: 25px;
+	grid-template-columns: 1fr 1fr;
 }
 
 /* 注文完了 */
 .ordered-item {
-    display: flex;
-    justify-content: center;
+	display: flex;
+	justify-content: center;
 	height: 30vh;
 }
 
@@ -521,7 +523,7 @@ footer small {
 	justify-content: center;
 	margin-top: 50px;
 	height: 30vh;
-    align-items: center;
+	align-items: center;
 }
 
 .round {
@@ -530,7 +532,7 @@ footer small {
 	border-radius: 50%;
 	display: flex;
 	height: 100px;
-    justify-content: center;
+	justify-content: center;
 	padding: 20px;
 	text-decoration: none;
 	width: 100px;

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -216,7 +216,7 @@ main {
 }
 
 .row-center {
-	/* 縦並び、中央寄せ */
+	/* 横並び、中央寄せ */
 	display: flex;
 	justify-content: center;
 }
@@ -227,7 +227,7 @@ main {
 	justify-content: space-around;
 }
 
-/* インライン要素をそろえる */
+/* インライン要素の配置をそろえる */
 .inline-center {
 	text-align: center;	
 }
@@ -240,6 +240,7 @@ main {
 	align-items: center;
 	background-color: var(--background-color-with-opacity);
 	border-radius: 10px;
+    box-sizing: border-box;
 	display: flex;
 	flex-flow: column;
 	gap: 20px 0;
@@ -247,6 +248,7 @@ main {
 	margin-top: 20px;
 	min-width: 40%;
 	padding: 20px 70px;
+	width: 100%;
 }
 
 .input-form div {
@@ -273,22 +275,24 @@ input-form img {
 	width: 400px;
 }
 
-/* 入力値表示フォーム */
+/* 表示フォーム */
 .output-form {
 	background-color: var(--background-color-with-opacity);
 	border-radius: 10px;
+    box-sizing: border-box;
 	display: flex;
 	flex-flow: column;
 	gap: 10px 0;
 	justify-content: center;
 	margin-top: 30px;
 	padding: 20px;
+	width: 100%;
 }
 
 .grid-1-1 {
 	display: grid;
 	gap: 10px;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: 50% 50%;
 }
 
 .font-emphasize {
@@ -531,24 +535,12 @@ footer small {
 	width: 100px;
 }
 
-/* 【管理】注文履歴一覧 */
-.history-container {
-	background-color: var(--background-color-with-opacity);
-	display: flex;
-	justify-content: center;
-	width: 80%;
-}
-
 /* 【管理】商品一覧 */
 .admin-item-list {
 	display: grid;
 	gap: 20px;
 	grid-template-columns: repeat(3, calc(100% / 3));
 	margin: 50px 0;
-}
-
-.admin-item-top-container {
-	text-align: center;
 }
 
 .admin-item-container {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -227,6 +227,14 @@ main {
 	justify-content: space-around;
 }
 
+/* インライン要素をそろえる */
+.inline-center {
+	text-align: center;	
+}
+.inline-right {
+    text-align: right;
+}
+
 /* 入力フォーム */
 .input-form {
 	align-items: center;
@@ -236,15 +244,19 @@ main {
 	flex-flow: column;
 	gap: 20px 0;
 	justify-content: center;
+	margin-top: 20px;
 	min-width: 40%;
-	padding: 10px;
+	padding: 20px 70px;
 }
 
 .input-form div {
-	align-items: left;
 	display: flex;
 	flex-flow: column;
 	width: 100%;
+}
+
+.input-form label {
+	font-weight: bold;
 }
 
 .input-form input,
@@ -261,9 +273,31 @@ input-form img {
 	width: 400px;
 }
 
+/* 入力値表示フォーム */
+.output-form {
+	background-color: var(--background-color-with-opacity);
+	border-radius: 10px;
+	display: flex;
+	flex-flow: column;
+	gap: 10px 0;
+	justify-content: center;
+	margin-top: 30px;
+	padding: 20px;
+}
+
+.grid-1-1 {
+	display: grid;
+	gap: 10px;
+	grid-template-columns: 1fr 1fr;
+}
+
 .font-emphasize {
 	font-weight: bold;
 	font-size: 18px;
+}
+
+.font-bold {
+	font-weight: bold;
 }
 
 .font-underline {
@@ -272,10 +306,12 @@ input-form img {
 
 .err-mes {
 	color: red;
+	font-weight: bold;
 }
 
 .success-mes {
 	color: var(--main-color);
+	font-weight: bold;
 }
 
 .margin-top-50 {
@@ -547,4 +583,11 @@ footer small {
 
 .admin-item-description {
 	overflow: auto;
+}
+
+/* レスポンシブ用の幅調整 */
+@media (min-width:750px) {
+	.width-half {
+		width: 50%;
+	}
 }

--- a/src/main/resources/static/js/common.js
+++ b/src/main/resources/static/js/common.js
@@ -22,29 +22,31 @@ function changeQuantity(selected_id, quantity) {
 }
 
 //　商品一覧にSlickを適用（完全にjqueryのScriptが読み込めてから実行）
-$(document).ready(function() {
-    $('.item-list-slider').slick({
-        centerMode: true, // 前後の要素を表示
-        dots: true, // インジケーターの表示
-        infinite: true, // 無限スクロール
-		responsive: [
-	      {
-	        breakpoint: 1025, // 1024px以下のサイズに適用
-	        settings: {
-	        	slidesToShow: 2,
-	        },
-	      },
-	      {
-	        breakpoint: 750, // 749px以下のサイズに適用
-	        settings: {
-	        	slidesToShow: 1,
-	        },
-	      },
-	    ],
-        slidesToShow: 3,
-        swipeToSlide: true // スワイプでの移動も可
-    });
-});
+if (typeof $.fn.slick !== 'undefined') {
+	$(document).ready(function() {
+	    $('.item-list-slider').slick({
+	        centerMode: true, // 前後の要素を表示
+	        dots: true, // インジケーターの表示
+	        infinite: true, // 無限スクロール
+			responsive: [
+		      {
+		        breakpoint: 1025, // 1024px以下のサイズに適用
+		        settings: {
+		        	slidesToShow: 2,
+		        },
+		      },
+		      {
+		        breakpoint: 750, // 749px以下のサイズに適用
+		        settings: {
+		        	slidesToShow: 1,
+		        },
+		      },
+		    ],
+	        slidesToShow: 3,
+	        swipeToSlide: true // スワイプでの移動も可
+	    });
+	});
+}
 
 //　指定されたあて先IDに紐づくあて先情報に書き換え
 function changeAddress(selected_address_id) {

--- a/src/main/resources/templates/addAddress.html
+++ b/src/main/resources/templates/addAddress.html
@@ -11,23 +11,23 @@
 	<hr>
 
 	<main>
-		<div class="main-container column-center">
+		<div class="main-container width-half">
 			<a href="/addresses">一覧画面に戻る</a>
 
 			<!--あて先入力欄-->
-			<form action="/addresses/create" method="post" class="item-container input-form">
+			<form action="/addresses/create" method="post" class="input-form">
 				<!-- エラーメッセージの表示 -->
 				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
-				
-				<div class="one-form-container">
+
+				<div>
 					<label>あて先名</label>
 					<input type="text" name="addressName" th:value="${addressName}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>郵便番号</label>
 					<input type="text" name="postNum" th:value="${address.postNum}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>都道府県</label>
 					<select name="prefecture">
 						<option
@@ -38,15 +38,15 @@
 						</option>
 					</select>
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>市区町村</label>
 					<input type="text" name="municipality" th:value="${address.municipality}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>番地</label>
 					<input type="text" name="houseNum" th:value="${address.houseNum}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>建物名・部屋番号</label>
 					<input type="text" name="buildingNameRoomNum" th:value="${address.buildingNameRoomNum}">
 				</div>

--- a/src/main/resources/templates/addAddress.html
+++ b/src/main/resources/templates/addAddress.html
@@ -20,15 +20,15 @@
 				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
 
 				<div>
-					<label>あて先名</label>
+					<label class="required">あて先名</label>
 					<input type="text" name="addressName" th:value="${addressName}">
 				</div>
 				<div>
-					<label>郵便番号</label>
+					<label class="required">郵便番号</label>
 					<input type="text" name="postNum" th:value="${address.postNum}">
 				</div>
 				<div>
-					<label>都道府県</label>
+					<label class="required">都道府県</label>
 					<select name="prefecture">
 						<option
 							th:each="prefecture:${prefectureList}"
@@ -39,11 +39,11 @@
 					</select>
 				</div>
 				<div>
-					<label>市区町村</label>
+					<label class="required">市区町村</label>
 					<input type="text" name="municipality" th:value="${address.municipality}">
 				</div>
 				<div>
-					<label>番地</label>
+					<label class="required">番地</label>
 					<input type="text" name="houseNum" th:value="${address.houseNum}">
 				</div>
 				<div>

--- a/src/main/resources/templates/addAddress.html
+++ b/src/main/resources/templates/addAddress.html
@@ -12,7 +12,7 @@
 
 	<main>
 		<div class="main-container width-half">
-			<a href="/addresses">一覧画面に戻る</a>
+			<a href="/addresses">＜ 一覧画面に戻る</a>
 
 			<!--あて先入力欄-->
 			<form action="/addresses/create" method="post" class="input-form">

--- a/src/main/resources/templates/addresses.html
+++ b/src/main/resources/templates/addresses.html
@@ -11,44 +11,54 @@
 	<hr>
 
 	<main>
-		<div class="main-container column-center">
+		<div class="main-container width-half">
 			<!-- 成功メッセージの表示 -->
-			<p class="success-mes" th:if="${successMes.length > 0}">[[${successMes}]]</p>
+			<div class="inline-center">
+				<p class="success-mes" th:if="${successMes.length > 0}">
+					[[${successMes}]]
+				</p>
+			</div>
 
-			<a href="/addresses/add">追加</a>
+			<form action="/addresses/add" method="get">
+				<button>追加</button>
+			</form>
 
 			<!--あて先の表示-->
 			<div
 				th:unless="${accountAddressList.size() == 0}"
 				th:each="accountAddress : ${accountAddressList}"
-				class="item-container input-form">
-				<h3>[[${accountAddress.addressName}]]</h3>
-				<div>
-					<span>郵便番号：</span>
+				class="output-form">
+				<div class="inline-center">
+					<h3>[[${accountAddress.addressName}]]</h3>
+				</div>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">郵便番号：</span>
 					[[${accountAddress.address.postNum}]]
 				</div>
-				<div>
-					<span>都道府県：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">都道府県：</span>
 					[[${accountAddress.address.prefecture}]]
 				</div>
-				<div>
-					<span>市区町村：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">市区町村：</span>
 					[[${accountAddress.address.municipality}]]
 				</div>
-				<div>
-					<span>番地：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">番地：</span>
 					[[${accountAddress.address.houseNum}]]
 				</div>
-				<div>
-					<span>建物名・部屋番号：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">建物名・部屋番号：</span>
 					[[${accountAddress.address.buildingNameRoomNum}]]
 				</div>
-				<form th:action="'/addresses/' + ${accountAddress.addressId} + '/edit'" method="get">
-					<button>編集</button>
-				</form>
-				<form th:action="'/addresses/' + ${accountAddress.addressId} + '/delete'" method="post">
-					<button>削除</button>
-				</form>
+				<div class="row-buttons">
+					<form th:action="'/addresses/' + ${accountAddress.addressId} + '/edit'" method="get">
+						<button>編集</button>
+					</form>
+					<form th:action="'/addresses/' + ${accountAddress.addressId} + '/delete'" method="post">
+						<button>削除</button>
+					</form>
+				</div>
 			</div>
 			<!--あて先がない場合-->
 			<p th:if="${accountAddressList.size() == 0}">

--- a/src/main/resources/templates/addresses.html
+++ b/src/main/resources/templates/addresses.html
@@ -61,9 +61,10 @@
 				</div>
 			</div>
 			<!--あて先がない場合-->
-			<p th:if="${accountAddressList.size() == 0}">
-				未登録です
-			</p>
+			<div th:if="${accountAddressList.size() == 0}" class="inline-center">
+				<p>あて先リストは未登録です。</p>
+				<a href="/items">商品一覧に戻る</a>
+			</div>
 		</div>
 	</main>
 

--- a/src/main/resources/templates/admin/addItem.html
+++ b/src/main/resources/templates/admin/addItem.html
@@ -9,8 +9,8 @@
 	<header th:replace="header"></header>
 
 	<main>
-		<div class="main-container column-center">
-			<a href="/admin/items" class="margin-top-50">一覧画面に戻る</a>
+		<div class="main-container width-half">
+			<a href="/admin/items">一覧画面に戻る</a>
 
 			<!--入力フォーム-->
 			<form action="/admin/items/create"
@@ -18,11 +18,11 @@
 				<!-- エラーメッセージの表示 -->
 				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
 
-				<div class="one-form-container">
+				<div>
 					<label>商品名</label>
 					<input type="text" name="name" th:value="${item.name}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>カテゴリ―</label>
 					<select name="categoryId">
 						<option
@@ -32,19 +32,19 @@
 							th:value="${category.id}" th:text="${category.name}"></option>										
 					</select>
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>価格</label>
 					<input type="number" name="price" th:value="${item.price}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>在庫数</label>
 					<input type="number" name="stock" th:value="${item.stock}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>説明文</label>
 					<textarea name="description">[[${item.description}]]</textarea>
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>画像</label>
 					<input type="file" name="imgFile" accept=".png, .jpg, jpeg">
 				</div>
@@ -53,6 +53,8 @@
 			</form>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/admin/addItem.html
+++ b/src/main/resources/templates/admin/addItem.html
@@ -10,7 +10,7 @@
 
 	<main>
 		<div class="main-container width-half">
-			<a href="/admin/items">一覧画面に戻る</a>
+			<a href="/admin/items">＜ 一覧画面に戻る</a>
 
 			<!--入力フォーム-->
 			<form action="/admin/items/create"

--- a/src/main/resources/templates/admin/addItem.html
+++ b/src/main/resources/templates/admin/addItem.html
@@ -19,11 +19,11 @@
 				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
 
 				<div>
-					<label>商品名</label>
+					<label class="required">商品名</label>
 					<input type="text" name="name" th:value="${item.name}">
 				</div>
 				<div>
-					<label>カテゴリ―</label>
+					<label class="required">カテゴリ―</label>
 					<select name="categoryId">
 						<option
 							th:if="${categories.size() != 0}"
@@ -33,11 +33,11 @@
 					</select>
 				</div>
 				<div>
-					<label>価格</label>
+					<label class="required">価格</label>
 					<input type="number" name="price" th:value="${item.price}">
 				</div>
 				<div>
-					<label>在庫数</label>
+					<label class="required">在庫数</label>
 					<input type="number" name="stock" th:value="${item.stock}">
 				</div>
 				<div>

--- a/src/main/resources/templates/admin/editItem.html
+++ b/src/main/resources/templates/admin/editItem.html
@@ -27,11 +27,11 @@
 						th:src="@{'/img/items/' + ${item.fileName}}">
 				</div>
 				<div>
-					<label>商品名</label>
+					<label class="required">商品名</label>
 					<input type="text" name="name" th:value="${item.name}">
 				</div>
 				<div>
-					<label>カテゴリ―</label>
+					<label class="required">カテゴリ―</label>
 					<select name="categoryId">
 						<option
 							th:if="${categories.size() != 0}"
@@ -41,11 +41,11 @@
 					</select>
 				</div>
 				<div>
-					<label>価格</label>
+					<label class="required">価格</label>
 					<input type="number" name="price" th:value="${item.price}">
 				</div>
 				<div>
-					<label>在庫数</label>
+					<label class="required">在庫数</label>
 					<input type="number" name="stock" th:value="${item.stock}">
 				</div>
 				<div>

--- a/src/main/resources/templates/admin/editItem.html
+++ b/src/main/resources/templates/admin/editItem.html
@@ -8,9 +8,11 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
-		<div class="main-container column-center">
-			<a href="/admin/items" class="margin-top-50">一覧画面に戻る</a>
+		<div class="main-container width-half">
+			<a href="/admin/items">一覧画面に戻る</a>
 
 			<!--入力フォーム-->
 			<form th:action="'/admin/items/' + ${item.id} + '/update'"
@@ -18,17 +20,17 @@
 				<!-- エラーメッセージの表示 -->
 				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
 
-				<div class="one-form-container">
+				<div class="column-center">
 					<img th:if="${item.fileName.equals('')}"
 						th:src="@{/img/common/no_image.jpg}">
 					<img th:unless="${item.fileName.equals('')}"
 						th:src="@{'/img/items/' + ${item.fileName}}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>商品名</label>
 					<input type="text" name="name" th:value="${item.name}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>カテゴリ―</label>
 					<select name="categoryId">
 						<option
@@ -38,19 +40,19 @@
 							th:value="${category.id}" th:text="${category.name}"></option>										
 					</select>
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>価格</label>
 					<input type="number" name="price" th:value="${item.price}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>在庫数</label>
 					<input type="number" name="stock" th:value="${item.stock}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>説明文</label>
 					<textarea name="description">[[${item.description}]]</textarea>
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>画像</label>
 					<input type="file" name="imgFile" accept=".png, .jpg, jpeg">
 					<span>※変更する場合のみ指定してください。</span>
@@ -61,6 +63,8 @@
 			</form>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/admin/editItem.html
+++ b/src/main/resources/templates/admin/editItem.html
@@ -12,7 +12,7 @@
 
 	<main>
 		<div class="main-container width-half">
-			<a href="/admin/items">一覧画面に戻る</a>
+			<a href="/admin/items">＜ 一覧画面に戻る</a>
 
 			<!--入力フォーム-->
 			<form th:action="'/admin/items/' + ${item.id} + '/update'"

--- a/src/main/resources/templates/admin/items.html
+++ b/src/main/resources/templates/admin/items.html
@@ -8,10 +8,12 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
 		<div class="main-container">
 			<!-- 成功メッセージの表示 -->
-			<div class="admin-item-top-container margin-top-50">
+			<div class="inline-center">
 				<p class="success-mes" th:if="${successMes.length > 0}">[[${successMes}]]</p>
 			</div>
 
@@ -100,6 +102,8 @@
 			</div>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/adminTop.html
+++ b/src/main/resources/templates/adminTop.html
@@ -7,7 +7,9 @@
 </head>
 <body>
 	<header th:replace="header"></header>
-	
+
+	<hr>
+
 	<main>
 		<div class="main-container">
 			<!-- 機能一覧 -->
@@ -17,6 +19,8 @@
 			</div>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/cart.html
+++ b/src/main/resources/templates/cart.html
@@ -10,6 +10,8 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
 		<div id="cart-items" th:fragment="cart-items" class="main-container column-center">
 			<div th:each="item:${@cart.items}" class="item-container">
@@ -51,6 +53,8 @@
 			</a>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/cart.html
+++ b/src/main/resources/templates/cart.html
@@ -13,27 +13,31 @@
 	<hr>
 
 	<main>
-		<div id="cart-items" th:fragment="cart-items" class="main-container column-center">
+		<div id="cart-items" th:fragment="cart-items" class="main-container column-center width-half">
 			<div th:each="item:${@cart.items}" class="item-container">
-				<img th:src="@{'/img/items/' + ${item.fileName}}">
+				<img th:if="${item.fileName.equals('')}"
+					th:src="@{/img/common/no_image.jpg}">
+				<img th:unless="${item.fileName.equals('')}"
+					th:src="@{'/img/items/' + ${item.fileName}}">
+
 				<div class="item-container-right">
-					<p class="font-emphasize" th:text="${item.name}"></p>
-					<p>
+					<span class="font-emphasize" th:text="${item.name}"></span>
+					<span>
 						<span>価格：</span>
 						<span th:utext="${@formatService.getFormattedPrice(item.price)}"></span>
-					</p>
-					<p>
+					</span>
+					<span>
 						<span>数量：</span>
 						<select name="quantity" th:onchange="'changeQuantity(' + ${item.id} + ', this.value)'">
 							//在庫数分のoptionを表示
 							//一覧・詳細から選択された数量を初期値に設定
 							<option th:each="i : ${#numbers.sequence(1,item.stock)}" th:selected="${i == item.quantity}"　th:value="${i}" th:text="${i}"></option>										
 						</select>
-					</p>
-					<p>
+					</span>
+					<span>
 						<span>小計：</span>
 						<span th:utext="${@formatService.getFormattedPrice(item.subTotalPrice)}"></span>
-					</p>
+					</span>
 					<form action="/cart/delete" method="post">
 						<input type="hidden" name="itemId" th:value="${item.id}">
 						<button>削除</button>
@@ -48,9 +52,11 @@
 				<span th:utext="${@formatService.getFormattedPrice(@cart.totalPrice)}"></span>
 			</div>
 
-			<a href="/order">
+			<form action="/order" method="get">
 				<button>注文画面に進む</button>
-			</a>
+			</form>
+<!--			<a href="/order">-->
+<!--			</a>-->
 		</div>
 	</main>
 

--- a/src/main/resources/templates/editAddress.html
+++ b/src/main/resources/templates/editAddress.html
@@ -15,7 +15,8 @@
 			<a href="/addresses">一覧画面に戻る</a>
 
 			<!--あて先入力欄-->
-			<form th:action="'/addresses/' + ${accountAddress.addressId} + '/update'" method="post" class="input-form">
+			<form th:action="'/addresses/' + ${accountAddress.addressId} + '/update'"
+				method="post" class="input-form">
 				<!-- エラーメッセージの表示 -->
 				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
 				

--- a/src/main/resources/templates/editAddress.html
+++ b/src/main/resources/templates/editAddress.html
@@ -12,7 +12,7 @@
 
 	<main>
 		<div class="main-container width-half">
-			<a href="/addresses">一覧画面に戻る</a>
+			<a href="/addresses">＜ 一覧画面に戻る</a>
 
 			<!--あて先入力欄-->
 			<form th:action="'/addresses/' + ${accountAddress.addressId} + '/update'"

--- a/src/main/resources/templates/editAddress.html
+++ b/src/main/resources/templates/editAddress.html
@@ -21,15 +21,15 @@
 				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
 				
 				<div>
-					<label>あて先名</label>
+					<label class="required">あて先名</label>
 					<input type="text" name="addressName" th:value="${accountAddress.addressName}">
 				</div>
 				<div>
-					<label>郵便番号</label>
+					<label class="required">郵便番号</label>
 					<input type="text" name="postNum" th:value="${accountAddress.address.postNum}">
 				</div>
 				<div>
-					<label>都道府県</label>
+					<label class="required">都道府県</label>
 					<select name="prefecture">
 						<option
 							th:each="prefecture:${prefectureList}"
@@ -40,11 +40,11 @@
 					</select>
 				</div>
 				<div>
-					<label>市区町村</label>
+					<label class="required">市区町村</label>
 					<input type="text" name="municipality" th:value="${accountAddress.address.municipality}">
 				</div>
 				<div>
-					<label>番地</label>
+					<label class="required">番地</label>
 					<input type="text" name="houseNum" th:value="${accountAddress.address.houseNum}">
 				</div>
 				<div>

--- a/src/main/resources/templates/editAddress.html
+++ b/src/main/resources/templates/editAddress.html
@@ -11,23 +11,23 @@
 	<hr>
 
 	<main>
-		<div class="main-container column-center">
+		<div class="main-container width-half">
 			<a href="/addresses">一覧画面に戻る</a>
 
 			<!--あて先入力欄-->
-			<form th:action="'/addresses/' + ${accountAddress.addressId} + '/update'" method="post" class="item-container input-form">
+			<form th:action="'/addresses/' + ${accountAddress.addressId} + '/update'" method="post" class="input-form">
 				<!-- エラーメッセージの表示 -->
 				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
 				
-				<div class="one-form-container">
+				<div>
 					<label>あて先名</label>
 					<input type="text" name="addressName" th:value="${accountAddress.addressName}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>郵便番号</label>
 					<input type="text" name="postNum" th:value="${accountAddress.address.postNum}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>都道府県</label>
 					<select name="prefecture">
 						<option
@@ -38,15 +38,15 @@
 						</option>
 					</select>
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>市区町村</label>
 					<input type="text" name="municipality" th:value="${accountAddress.address.municipality}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>番地</label>
 					<input type="text" name="houseNum" th:value="${accountAddress.address.houseNum}">
 				</div>
-				<div class="one-form-container">
+				<div>
 					<label>建物名・部屋番号</label>
 					<input type="text" name="buildingNameRoomNum" th:value="${accountAddress.address.buildingNameRoomNum}">
 				</div>

--- a/src/main/resources/templates/error403.html
+++ b/src/main/resources/templates/error403.html
@@ -7,7 +7,9 @@
 </head>
 <body>
 	<header th:replace="header"></header>
-	
+
+	<hr>
+
 	<main>
 		<div class="main-container">
 			<div class="column-center">
@@ -16,6 +18,8 @@
 			</div>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -1,7 +1,7 @@
 <header>
 	<nav class="header-menu">
 		<div class="header-menu-title">
-			<h1><a href="/items">使いやすい<br class="sp">ショッピングサイト</a></h1>
+			<h1><a href="/items">Spring <br class="sp">Shopping</a></h1>
 		</div>
 		<span class="header-menu-container">
 			<th:block th:if="${@loginUser.isLogin()}">
@@ -23,7 +23,7 @@
 
 			<div class="header-menu-login">
 				<th:block th:if="${@loginUser.isLogin()}">
-					[[${@loginUser.getName()}]]
+					[[${@loginUser.getName()}]]様
 					<a href="/logout">ログアウト</a>
 				</th:block>
 				<th:block th:unless="${@loginUser.isLogin()}">

--- a/src/main/resources/templates/histories.html
+++ b/src/main/resources/templates/histories.html
@@ -12,7 +12,7 @@
 
 	<main>
 		<div class="main-container width-half">
-			<a href="/admin">TOPに戻る</a>
+			<a href="/admin">＜ TOPに戻る</a>
 
 			<!-- 注文履歴一覧 -->
 			<div class="column-center">

--- a/src/main/resources/templates/histories.html
+++ b/src/main/resources/templates/histories.html
@@ -8,26 +8,47 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
-		<div class="main-container column-center histories-container">
-			<a href="/admin" class="margin-top-50">TOPに戻る</a>
+		<div class="main-container width-half">
+			<a href="/admin">TOPに戻る</a>
 
 			<!-- 注文履歴一覧 -->
-			<div th:each="order:${orderList}" class="history-container">
-				<div>
-					<p>アカウント名：[[${order.acoountName}]]</p>
-					<p>注文日時：[[${order.orderedDatetime}]]</p>
-					<p>合計金額：<span th:utext="${@formatService.getFormattedPrice(order.totalPrice)}"></span></p>
-					<p>あて先：[[${order.prefecture}]]</p>
-					<p class="column-center">
+			<div class="column-center">
+				<div th:if="${orderList.isEmpty()}" class="inline-center">
+					<p>注文履歴はございません。</p>
+				</div>
+				<div th:unless="${orderList.isEmpty()}" th:each="order:${orderList}"
+					class="output-form">
+					<div class="grid-1-1">
+						<span class="font-bold inline-right">アカウント名：</span>
+						[[${order.acoountName}]]
+					</div>
+					<div class="grid-1-1">
+						<span class="font-bold inline-right">注文日時：</span>
+						[[${order.orderedDatetime}]]
+					</div>
+					<div class="grid-1-1">
+						<span class="font-bold inline-right">合計金額：</span>
+						<span th:utext="${@formatService.getFormattedPrice(order.totalPrice)}"></span>
+					</div>
+					<div class="grid-1-1">
+						<span class="font-bold inline-right">あて先：</span>
+						[[${order.prefecture}]]
+					</div>
+					<div class="inline-center">
 						<a th:href="'/admin/order/histories/' + ${order.id}">
 							詳細
 						</a>
-					</p>
+					</div>
 				</div>
+				
 			</div>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -67,14 +67,18 @@
 				<form action="/cart/add" method="post" th:each="item:${items}">
 					<div class="item">
 						<a th:href="'/items/' + ${item.id}" class="item-img">
-							<img th:src="@{'/img/items/' + ${item.fileName}}">
+							<img th:if="${item.fileName.equals('')}"
+								th:src="@{/img/common/no_image.jpg}">
+							<img th:unless="${item.fileName.equals('')}"
+								th:src="@{'/img/items/' + ${item.fileName}}">
 						</a>
 						<a th:href="'/items/' + ${item.id}" class="item-name">
 							<span th:text="${item.name}"></span>								
 						</a>
 						<span th:utext="${@formatService.getFormattedPrice(item.price)}"
 							class="item-price"></span>
-						<span class="item-quantity">数量：
+						<span class="item-quantity">
+							数量：
 							<select name="quantity" th:if="${item.stock > 0}">
 								//在庫数分のoptionを表示
 								<option

--- a/src/main/resources/templates/items.html
+++ b/src/main/resources/templates/items.html
@@ -92,8 +92,9 @@
 		</div>
 	</main>
 
+	<hr>
+
 	<footer th:replace="footer"></footer>
-	
 	
 </body>
 </html>

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -11,24 +11,26 @@
 	<hr>
 
 	<main>
-		<div class="main-container column-center">
-			<form action="/login" method="post" class="auth-container input-form">
+		<div class="main-container width-half">
+			<form action="/login" method="post" class="input-form">
 				<!-- エラー・成功メッセージの表示 -->
-				<p class="font-emphasize err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
-				<p class="font-emphasize success-mes" th:if="${successMes.length > 0}">[[${successMes}]]</p>
+				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
+				<p class="success-mes" th:if="${successMes.length > 0}">[[${successMes}]]</p>
 
 				<div>
-					<span>メールアドレス</span>
+					<label class="required">メールアドレス</label>
 					<input type="email" name="email" th:value="${email}">					
 				</div>
 				<div>
-					<span>パスワード</span>
+					<label class="required">パスワード</label>
 					<input type="password" name="password" th:value="${password}">					
 				</div>
 				<button>ログイン</button>
 			</form>
 
-			<a href="/register">アカウントの新規作成</a>
+			<div class="inline-center">
+				<a href="/register">アカウントの新規作成</a>
+			</div>
 		</div>
 	</main>
 

--- a/src/main/resources/templates/loginForm.html
+++ b/src/main/resources/templates/loginForm.html
@@ -7,7 +7,9 @@
 </head>
 <body>
 	<header th:replace="header"></header>
-	
+
+	<hr>
+
 	<main>
 		<div class="main-container column-center">
 			<form action="/login" method="post" class="auth-container input-form">
@@ -29,6 +31,8 @@
 			<a href="/register">アカウントの新規作成</a>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/loginUserOrderHistories.html
+++ b/src/main/resources/templates/loginUserOrderHistories.html
@@ -8,29 +8,44 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
-		<div class="main-container column-center">
-			<div class="account-name">
-				<p th:text="${@loginUser.name} + '様　ご注文履歴一覧'"></p>
+		<div class="main-container column-center width-half">
+			<p th:text="${@loginUser.name} + '様　ご注文履歴一覧'"></p>
+
+			<div th:if="${loginUserOrderList.isEmpty()}" class="inline-center">
+				<p>注文履歴はございません。</p>
+				<a href="/items">商品一覧に戻る</a>
 			</div>
-			<div th:if="${loginUserOrderList.isEmpty()}">
-				<p>注文履歴はございません</p>
-				<a href="/items">TOPに戻る</a>
-			</div>
-			<div th:unless="${loginUserOrderList.isEmpty()}" th:each="order:${loginUserOrderList}" class="history-container">
-				<div>
-					<p>注文日時：[[${order.orderedDatetime}]]</p>
-					<p>合計金額：[[${order.totalPrice}]]</p>
-					<p>あて先：[[${order.prefecture}]]</p>
-					<p class="column-center">
-						<a th:href="'/loginUser/order/history/' + ${order.id}">
-							詳細
-						</a>
-					</p>
+			<div th:unless="${loginUserOrderList.isEmpty()}"
+				th:each="order:${loginUserOrderList}" class="output-form">
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">注文日時：</span>
+					[[${order.orderedDatetime}]]
+				</div>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">合計金額：</span>
+					[[${order.totalPrice}]]
+				</div>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">あて先：</span>
+					[[${order.prefecture}]]
+				</div>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">注文日時：</span>
+					[[${order.orderedDatetime}]]
+				</div>
+				<div class="inline-center">
+					<a th:href="'/loginUser/order/history/' + ${order.id}">
+						詳細
+					</a>
 				</div>
 			</div>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/loginUserShowOrderHistory.html
+++ b/src/main/resources/templates/loginUserShowOrderHistory.html
@@ -12,7 +12,7 @@
 
 	<main>
 		<div class="main-container width-half">
-			<a href="/loginUser/order/histories">一覧画面に戻る</a>
+			<a href="/loginUser/order/histories">＜ 一覧画面に戻る</a>
 
 			<!-- 注文履歴概要 -->
 			<div class="output-form">

--- a/src/main/resources/templates/loginUserShowOrderHistory.html
+++ b/src/main/resources/templates/loginUserShowOrderHistory.html
@@ -8,39 +8,47 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
-		<div class="main-container column-center">
+		<div class="main-container width-half">
 			<a href="/loginUser/order/histories">一覧画面に戻る</a>
 
 			<!-- 注文履歴概要 -->
-			<div class="history-container">
-				<div>
-					<p>注文日時：[[${loginUserOrderInfo.orderedDatetime}]]</p>
-					<p>合計金額：<span th:utext="${@formatService.getFormattedPrice(loginUserOrderInfo.totalPrice)}"></span></p>
+			<div class="output-form">
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">注文日時：</span>
+					[[${loginUserOrderInfo.orderedDatetime}]]
+				</div>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">合計金額：</span>
+					<span th:utext="${@formatService.getFormattedPrice(loginUserOrderInfo.totalPrice)}"></span>
 				</div>
 			</div>
 
 			<!-- あて先表示 -->
-			<div class="input-form">
-				<strong>あて先</strong>
-				<div>
-					<span>郵便番号：</span>
+			<div class="output-form">
+				<div class="inline-center">
+					<h3>あて先</h3>
+				</div>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">郵便番号：</span>
 					[[${loginUserOrderInfo.postNum}]]
 				</div>
-				<div>
-					<span>都道府県：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">都道府県：</span>
 					[[${loginUserOrderInfo.prefecture}]]
 				</div>
-				<div>
-					<span>市区町村：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">市区町村：</span>
 					[[${loginUserOrderInfo.municipality}]]
 				</div>
-				<div>
-					<span>番地：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">番地：</span>
 					[[${loginUserOrderInfo.houseNum}]]
 				</div>
-				<div>
-					<span>建物名・部屋番号：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">建物名・部屋番号：</span>
 					[[${loginUserOrderInfo.buildingNameRoomNum}]]
 				</div>
 			</div>
@@ -48,24 +56,28 @@
 			<hr class="dots-line">
 
 			<!-- 商品履歴詳細 -->
-			<div class="column-center">
-				<div th:each="orderHistoryDetail:${loginUserOrderHistoryDetailList}" class="item-container">
-					<img th:src="@{'/img/items/' + ${orderHistoryDetail.fileName}}">
-					<div class="item-container-right">
-						<span class="font-emphasize" th:text="${orderHistoryDetail.itemName}"></span>
-						<div>
-							<span>価格</span>
-							<span th:utext="${@formatService.getFormattedPrice(orderHistoryDetail.itemPrice)}"></span>
-						</div>
-						<div>
-							<span>数量</span>
-							<span th:text="${orderHistoryDetail.quantity}"></span>
-						</div>
+			<div th:each="orderHistoryDetail:${loginUserOrderHistoryDetailList}" class="item-container">
+				<img th:if="${orderHistoryDetail.fileName.equals('')}"
+					th:src="@{/img/common/no_image.jpg}">
+				<img th:unless="${orderHistoryDetail.fileName.equals('')}"
+					th:src="@{'/img/items/' + ${orderHistoryDetail.fileName}}">
+
+				<div class="item-container-right">
+					<span class="font-emphasize" th:text="${orderHistoryDetail.itemName}"></span>
+					<div>
+						<span>価格</span>
+						<span th:utext="${@formatService.getFormattedPrice(orderHistoryDetail.itemPrice)}"></span>
+					</div>
+					<div>
+						<span>数量</span>
+						<span th:text="${orderHistoryDetail.quantity}"></span>
 					</div>
 				</div>
 			</div>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/order.html
+++ b/src/main/resources/templates/order.html
@@ -10,6 +10,8 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
 		<div class="main-container column-center">
 			<div th:each="item:${@cart.items}" class="item-container">
@@ -49,7 +51,7 @@
 						th:value="${address.addressId}" th:text="${stat.count} + '. ' + ${address.addressName}"></option>										
 				</select>
 
-				<div class="one-form-container">
+				<div>
 					<label>郵便番号</label>
 					<input type="text" name="postNum" th:value="${address.postNum}"
 						th:disabled="${selectedAddressId != 0}">
@@ -103,9 +105,11 @@
 
 			<a href="/cart">カートに戻る</a>
 
-    </div>
+    	</div>
 	</main>
-	
+
+	<hr>
+
 	<footer th:replace="footer"></footer>
 </body>
 </html>

--- a/src/main/resources/templates/order.html
+++ b/src/main/resources/templates/order.html
@@ -14,7 +14,7 @@
 
 	<main>
 		<div class="main-container width-half">
-			<a href="/cart">カートに戻る</a>
+			<a href="/cart">＜ カートに戻る</a>
 
 			<div class="column-center">
 				<div th:each="item:${@cart.items}" class="item-container">

--- a/src/main/resources/templates/order.html
+++ b/src/main/resources/templates/order.html
@@ -13,99 +13,104 @@
 	<hr>
 
 	<main>
-		<div class="main-container column-center">
-			<div th:each="item:${@cart.items}" class="item-container">
-				<img th:src="@{'/img/items/' + ${item.fileName}}">
-				<div class="item-container-right">
-					<span class="font-emphasize" th:text="${item.name}"></span>
-					<p>
-						<span>価格：</span>
-						<span th:utext="${@formatService.getFormattedPrice(item.price)}"></span>
-					</p>
-					<p>
-						<span>数量：</span>
-						<span th:text="${item.quantity}"></span>
-					</p>
-					<p>
-						<span>小計：</span>
-						<span th:utext="${@formatService.getFormattedPrice(item.subTotalPrice)}"></span>
-					</p>
-				</div>
-			</div>
-
-			<!-- あて先入力欄 -->
-			<form action="/order/confirm" method="post" class="input-form"
-				id="address-form" th:fragment="address-form">
-				<!-- エラーメッセージの表示 -->
-				<div class="font-emphasize err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</div>
-
-				<!-- あて先リストの表示 -->
-				<select onchange="changeAddress(this.value)">
-					<!--手入力　＋　あて先リストの内容-->
-					<option th:selected="${selectedAddressId == 0}"
-						value="0">0. 手入力</option>										
-					<option
-						th:if="${accountAddressList != null}"
-						th:each="address, stat : ${accountAddressList}"
-						th:selected="${selectedAddressId == address.addressId}"
-						th:value="${address.addressId}" th:text="${stat.count} + '. ' + ${address.addressName}"></option>										
-				</select>
-
-				<div>
-					<label>郵便番号</label>
-					<input type="text" name="postNum" th:value="${address.postNum}"
-						th:disabled="${selectedAddressId != 0}">
-				</div>
-				<div>
-					<label>都道府県</label>
-					<select name="prefecture" th:disabled="${selectedAddressId != 0}">
-						<option
-							th:each="prefecture:${prefectureList}"
-							th:value="${prefecture}"
-							th:selected="${address.isPrefectureSet(prefecture)}">
-							[[${prefecture}]]
-						</option>
-					</select>
-				</div>
-				<div>
-					<label>市区町村</label>
-					<input type="text" name="municipality" th:value="${address.municipality}"
-						th:disabled="${selectedAddressId != 0}">
-				</div>
-				<div>
-					<label>番地</label>
-					<input type="text" name="houseNum" th:value="${address.houseNum}"
-						th:disabled="${selectedAddressId != 0}">
-				</div>
-				<div>
-					<label>建物名・部屋番号</label>
-					<input type="text" name="buildingNameRoomNum"
-						th:value="${address.buildingNameRoomNum}"
-						th:disabled="${selectedAddressId != 0}">
-				</div>
-
-				<!-- あて先リストから取得した情報をサーバーに送るため（disbledで値が消えてしまう） -->
-				<th:block th:if="${selectedAddressId != 0}">
-					<input type="hidden" name="postNum" th:value="${address.postNum}">
-					<input type="hidden" name="prefecture" th:value="${address.prefecture}">
-					<input type="hidden" name="municipality" th:value="${address.municipality}">
-					<input type="hidden" name="houseNum" th:value="${address.houseNum}">
-					<input type="hidden" name="buildingNameRoomNum" th:value="${address.buildingNameRoomNum}">
-				</th:block>
-
-				<button>注文内容を確認する</button>
-			</form>
-
-			<hr class="dots-line">
-
-			<div class="font-emphasize">
-				<span>合計：</span>
-				<span th:utext="${@formatService.getFormattedPrice(@cart.totalPrice)}"></span>
-			</div>
-
+		<div class="main-container width-half">
 			<a href="/cart">カートに戻る</a>
 
-    	</div>
+			<div class="column-center">
+				<div th:each="item:${@cart.items}" class="item-container">
+					<img th:if="${item.fileName.equals('')}"
+						th:src="@{/img/common/no_image.jpg}">
+					<img th:unless="${item.fileName.equals('')}"
+						th:src="@{'/img/items/' + ${item.fileName}}">
+
+					<div class="item-container-right">
+						<span class="font-emphasize" th:text="${item.name}"></span>
+						<p>
+							<span>価格：</span>
+							<span th:utext="${@formatService.getFormattedPrice(item.price)}"></span>
+						</p>
+						<p>
+							<span>数量：</span>
+							<span th:text="${item.quantity}"></span>
+						</p>
+						<p>
+							<span>小計：</span>
+							<span th:utext="${@formatService.getFormattedPrice(item.subTotalPrice)}"></span>
+						</p>
+					</div>
+				</div>
+	
+				<!-- あて先入力欄 -->
+				<form action="/order/confirm" method="post" class="input-form"
+					id="address-form" th:fragment="address-form">
+					<!-- エラーメッセージの表示 -->
+					<div class="font-emphasize err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</div>
+	
+					<!-- あて先リストの表示 -->
+					<select onchange="changeAddress(this.value)">
+						<!--手入力　＋　あて先リストの内容-->
+						<option th:selected="${selectedAddressId == 0}"
+							value="0">0. 手入力</option>										
+						<option
+							th:if="${accountAddressList != null}"
+							th:each="address, stat : ${accountAddressList}"
+							th:selected="${selectedAddressId == address.addressId}"
+							th:value="${address.addressId}" th:text="${stat.count} + '. ' + ${address.addressName}"></option>										
+					</select>
+	
+					<div>
+						<label class="required">郵便番号</label>
+						<input type="text" name="postNum" th:value="${address.postNum}"
+							th:disabled="${selectedAddressId != 0}">
+					</div>
+					<div>
+						<label class="required">都道府県</label>
+						<select name="prefecture" th:disabled="${selectedAddressId != 0}">
+							<option
+								th:each="prefecture:${prefectureList}"
+								th:value="${prefecture}"
+								th:selected="${address.isPrefectureSet(prefecture)}">
+								[[${prefecture}]]
+							</option>
+						</select>
+					</div>
+					<div>
+						<label class="required">市区町村</label>
+						<input type="text" name="municipality" th:value="${address.municipality}"
+							th:disabled="${selectedAddressId != 0}">
+					</div>
+					<div>
+						<label class="required">番地</label>
+						<input type="text" name="houseNum" th:value="${address.houseNum}"
+							th:disabled="${selectedAddressId != 0}">
+					</div>
+					<div>
+						<label>建物名・部屋番号</label>
+						<input type="text" name="buildingNameRoomNum"
+							th:value="${address.buildingNameRoomNum}"
+							th:disabled="${selectedAddressId != 0}">
+					</div>
+	
+					<!-- あて先リストから取得した情報をサーバーに送るため（disbledで値が消えてしまう） -->
+					<th:block th:if="${selectedAddressId != 0}">
+						<input type="hidden" name="postNum" th:value="${address.postNum}">
+						<input type="hidden" name="prefecture" th:value="${address.prefecture}">
+						<input type="hidden" name="municipality" th:value="${address.municipality}">
+						<input type="hidden" name="houseNum" th:value="${address.houseNum}">
+						<input type="hidden" name="buildingNameRoomNum" th:value="${address.buildingNameRoomNum}">
+					</th:block>
+	
+					<button>注文内容を確認する</button>
+				</form>
+	
+				<hr class="dots-line">
+	
+				<div class="font-emphasize">
+					<span>合計：</span>
+					<span th:utext="${@formatService.getFormattedPrice(@cart.totalPrice)}"></span>
+				</div>
+			</div>
+	   	</div>
 	</main>
 
 	<hr>

--- a/src/main/resources/templates/orderConfirm.html
+++ b/src/main/resources/templates/orderConfirm.html
@@ -11,10 +11,10 @@
 	<hr>
 
 	<main>
-		<div class="main-container column-center">
-			<div class="column-center order-confirm-container">
-				<a href="/order">注文画面に戻る</a>
+		<div class="main-container width-half">
+			<a href="/order">注文画面に戻る</a>
 
+			<div class="column-center">
 				<form action="/order" method="post">
 					<input type="hidden" name="postNum" th:value="${confirmedAddress.postNum}">
 					<input type="hidden" name="prefecture" th:value="${confirmedAddress.prefecture}">
@@ -24,34 +24,34 @@
 					<button>この内容で注文</button>
 				</form>
 	
-				<div class="column-center total-price-item font-emphasize">
-					<p>請求額</p>
+				<div class="inline-center font-emphasize">
+					<p class="font-underline">請求額</p>
 					<p th:utext="${@formatService.getFormattedPrice(@cart.totalPrice)}"></p>
 				</div>
 
 				<hr class="dots-line">
 
 				<!-- あて先表示 -->
-				<p class="font-emphasize font-underline">お届け先</p>
-				<div class="input-form">
-					<div>
-						<span>郵便番号：</span>
+				<span class="font-emphasize font-underline">お届け先</span>
+				<div class="output-form">
+					<div class="grid-1-1">
+						<span class="font-bold inline-right">郵便番号：</span>
 						[[${confirmedAddress.postNum}]]
 					</div>
-					<div>
-						<span>都道府県：</span>
+					<div class="grid-1-1">
+						<span class="font-bold inline-right">都道府県：</span>
 						[[${confirmedAddress.prefecture}]]
 					</div>
-					<div>
-						<span>市区町村：</span>
+					<div class="grid-1-1">
+						<span class="font-bold inline-right">市区町村：</span>
 						[[${confirmedAddress.municipality}]]
 					</div>
-					<div>
-						<span>番地：</span>
+					<div class="grid-1-1">
+						<span class="font-bold inline-right">番地：</span>
 						[[${confirmedAddress.houseNum}]]
 					</div>
-					<div>
-						<span>建物名・部屋番号：</span>
+					<div class="grid-1-1">
+						<span class="font-bold inline-right">建物名・部屋番号：</span>
 						[[${confirmedAddress.buildingNameRoomNum}]]
 					</div>
 				</div>
@@ -60,7 +60,11 @@
 
 				<div class="column-center">
 					<div th:each="item:${@cart.items}" class="item-container">
-						<img th:src="@{'/img/items/' + ${item.fileName}}">
+						<img th:if="${item.fileName.equals('')}"
+							th:src="@{/img/common/no_image.jpg}">
+						<img th:unless="${item.fileName.equals('')}"
+							th:src="@{'/img/items/' + ${item.fileName}}">
+
 						<div class="item-container-right">
 							<span class="font-emphasize" th:text="${item.name}"></span>
 							<p>

--- a/src/main/resources/templates/orderConfirm.html
+++ b/src/main/resources/templates/orderConfirm.html
@@ -12,7 +12,7 @@
 
 	<main>
 		<div class="main-container width-half">
-			<a href="/order">注文画面に戻る</a>
+			<a href="/order">＜ 注文画面に戻る</a>
 
 			<div class="column-center">
 				<form action="/order" method="post">

--- a/src/main/resources/templates/orderConfirm.html
+++ b/src/main/resources/templates/orderConfirm.html
@@ -8,6 +8,8 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
 		<div class="main-container column-center">
 			<div class="column-center order-confirm-container">
@@ -76,6 +78,7 @@
 		</div>
 	</main>
 
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/ordered.html
+++ b/src/main/resources/templates/ordered.html
@@ -11,7 +11,7 @@
 	<hr>
 
 	<main>
-		<div class="main-container column-center">
+		<div class="main-container width-half">
 			<div class="column-center ordered-item">
 				<p class="font-emphasize">注文が確定しました。</p>
 				<div>

--- a/src/main/resources/templates/ordered.html
+++ b/src/main/resources/templates/ordered.html
@@ -8,6 +8,8 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
 		<div class="main-container column-center">
 			<div class="column-center ordered-item">
@@ -20,6 +22,8 @@
 			</div>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/registerForm.html
+++ b/src/main/resources/templates/registerForm.html
@@ -32,7 +32,7 @@
 			</form>
 
 			<div class="inline-center">
-				<a href="/login">ログイン画面に戻る</a>
+				<a href="/login">＜ ログイン画面に戻る</a>
 			</div>
 		</div>
 	</main>

--- a/src/main/resources/templates/registerForm.html
+++ b/src/main/resources/templates/registerForm.html
@@ -8,6 +8,8 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
 		<div class="main-container column-center">
 			<form action="/register" method="post" class="auth-container input-form">
@@ -30,6 +32,8 @@
 			</form>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/registerForm.html
+++ b/src/main/resources/templates/registerForm.html
@@ -30,6 +30,10 @@
 				</div>
 				<button>新規登録</button>
 			</form>
+
+			<div class="inline-center">
+				<a href="/login">ログイン画面に戻る</a>
+			</div>
 		</div>
 	</main>
 

--- a/src/main/resources/templates/registerForm.html
+++ b/src/main/resources/templates/registerForm.html
@@ -11,21 +11,21 @@
 	<hr>
 
 	<main>
-		<div class="main-container column-center">
-			<form action="/register" method="post" class="auth-container input-form">
+		<div class="main-container width-half">
+			<form action="/register" method="post" class="input-form">
 				<!-- エラーメッセージの表示 -->
-				<p class="font-emphasize err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
+				<p class="err-mes" th:if="${errMes.length > 0}">[[${errMes}]]</p>
 
 				<div>
-					<span>名前</span>
+					<label class="required">名前</label>
 					<input type="text" name="name" th:value="${name}">					
 				</div>
 				<div>
-					<span>メールアドレス</span>
+					<label class="required">メールアドレス</label>
 					<input type="email" name="email" th:value="${email}">					
 				</div>
 				<div>
-					<span>パスワード</span>
+					<label class="required">パスワード</label>
 					<input type="password" name="password" th:value="${password}">					
 				</div>
 				<button>新規登録</button>

--- a/src/main/resources/templates/showHistory.html
+++ b/src/main/resources/templates/showHistory.html
@@ -8,40 +8,51 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
-		<div class="main-container column-center">
-			<a href="/admin/order/histories" class="margin-top-50">一覧画面に戻る</a>
+		<div class="main-container width-half">
+			<a href="/admin/order/histories">一覧画面に戻る</a>
 
 			<!-- 注文履歴概要 -->
-			<div class="history-container">
-				<div>
-					<p>アカウント名：[[${orderInfo.acoountName}]]</p>
-					<p>注文日時：[[${orderInfo.orderedDatetime}]]</p>
-					<p>合計金額：<span th:utext="${@formatService.getFormattedPrice(orderInfo.totalPrice)}"></span></p>
+			<div class="output-form">
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">アカウント名：</span>
+					[[${orderInfo.acoountName}]]
+				</div>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">注文日時：</span>
+					[[${orderInfo.orderedDatetime}]]
+				</div>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">合計金額：</span>
+					<span th:utext="${@formatService.getFormattedPrice(orderInfo.totalPrice)}"></span>
 				</div>
 			</div>
 
 			<!-- あて先表示 -->
-			<div class="input-form">
-				<strong>あて先</strong>
-				<div>
-					<span>郵便番号：</span>
+			<div class="output-form">
+				<div class="inline-center">
+					<h3>あて先</h3>
+				</div>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">郵便番号：</span>
 					[[${orderInfo.postNum}]]
 				</div>
-				<div>
-					<span>都道府県：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">都道府県：</span>
 					[[${orderInfo.prefecture}]]
 				</div>
-				<div>
-					<span>市区町村：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">市区町村：</span>
 					[[${orderInfo.municipality}]]
 				</div>
-				<div>
-					<span>番地：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">番地：</span>
 					[[${orderInfo.houseNum}]]
 				</div>
-				<div>
-					<span>建物名・部屋番号：</span>
+				<div class="grid-1-1">
+					<span class="font-bold inline-right">建物名・部屋番号：</span>
 					[[${orderInfo.buildingNameRoomNum}]]
 				</div>
 			</div>
@@ -49,24 +60,28 @@
 			<hr class="dots-line">
 
 			<!-- 商品履歴詳細 -->
-			<div class="column-center">
-				<div th:each="orderHistoryDetail:${orderHistoryDetailList}" class="item-container">
-					<img th:src="@{'/img/items/' + ${orderHistoryDetail.fileName}}">
-					<div class="item-container-right">
-						<span class="font-emphasize" th:text="${orderHistoryDetail.itemName}"></span>
-						<div>
-							<span>価格</span>
-							<span th:utext="${@formatService.getFormattedPrice(orderHistoryDetail.itemPrice)}"></span>
-						</div>
-						<div>
-							<span>数量</span>
-							<span th:text="${orderHistoryDetail.quantity}"></span>
-						</div>
+			<div th:each="orderHistoryDetail:${orderHistoryDetailList}" class="item-container">
+				<img th:if="${orderHistoryDetail.fileName.equals('')}"
+					th:src="@{/img/common/no_image.jpg}">
+				<img th:unless="${orderHistoryDetail.fileName.equals('')}"
+					th:src="@{'/img/items/' + ${orderHistoryDetail.fileName}}">
+
+				<div class="item-container-right">
+					<span class="font-emphasize" th:text="${orderHistoryDetail.itemName}"></span>
+					<div>
+						<span>価格</span>
+						<span th:utext="${@formatService.getFormattedPrice(orderHistoryDetail.itemPrice)}"></span>
+					</div>
+					<div>
+						<span>数量</span>
+						<span th:text="${orderHistoryDetail.quantity}"></span>
 					</div>
 				</div>
 			</div>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/showHistory.html
+++ b/src/main/resources/templates/showHistory.html
@@ -12,7 +12,7 @@
 
 	<main>
 		<div class="main-container width-half">
-			<a href="/admin/order/histories">一覧画面に戻る</a>
+			<a href="/admin/order/histories">＜ 一覧画面に戻る</a>
 
 			<!-- 注文履歴概要 -->
 			<div class="output-form">

--- a/src/main/resources/templates/showItem.html
+++ b/src/main/resources/templates/showItem.html
@@ -8,6 +8,8 @@
 <body>
 	<header th:replace="header"></header>
 
+	<hr>
+
 	<main>
 		<div class="main-container column-center">
 			<div class="item-container show-item">
@@ -45,6 +47,8 @@
 			</div>
 		</div>
 	</main>
+
+	<hr>
 
 	<footer th:replace="footer"></footer>
 </body>

--- a/src/main/resources/templates/showItem.html
+++ b/src/main/resources/templates/showItem.html
@@ -13,7 +13,11 @@
 	<main>
 		<div class="main-container column-center">
 			<div class="item-container show-item">
-				<img th:src="@{'/img/items/' + ${item.fileName}}">
+				<img th:if="${item.fileName.equals('')}"
+					th:src="@{/img/common/no_image.jpg}">
+				<img th:unless="${item.fileName.equals('')}"
+					th:src="@{'/img/items/' + ${item.fileName}}">
+
 				<div class="item-container-right">
 					<span class="font-emphasize" th:text="${item.name}"></span>
 					<p>価格：
@@ -27,7 +31,8 @@
 					<hr class="dots-line">
 
 					<form action="/cart/add" method="post">
-						<span>数量：
+						<span class="grid-1-4">
+							数量：
 							<select name="quantity" th:if="${item.stock > 0}">
 								//在庫数分のoptionを表示
 								<option
@@ -39,10 +44,9 @@
 						</span>
 						<span>
 							<input type="hidden" name="itemId" th:value="${item.id}">
-							<button　th:disabled="${item.stock <= 0}">カートに追加</button>
+							<button th:disabled="${item.stock <= 0}">カートに追加</button>
 						</span>
 					</form>
-	
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
### 対象の画面
 - 共通
   - mainの幅を目いっぱい使う必要がない画面
     - 幅が750px以上なら画面幅が50%になるように指定
   - 入力フォーム
     - ラベルを太字に
     - paddingの余白を追加
     - 必須項目には必須マークを追加
   - 表示フォーム
     - 全体的に中央寄せになるように変更
     - 複数のボタンは横並びに
   - 最上部にある前の画面に戻る系のリンクは左寄せに変更（リンクがなかったところには追加、先頭に「＜ 」も追加）
   - エラーメッセージ、成功メッセージは太字にして中央寄せ、ついでに文言も微修正
   - 商品の画像がない場合はデフォルトの画像を差し込む
   - 全体のfont-familyを「cursive」に設定、少し角が丸くなる感じに
 - あて先リスト一覧、追加、編集
   - 一覧
     - 追加はボタンに変更して画面幅いっぱい
     - 1つもない場合はログインユーザーの注文履歴一覧と同じように、商品一覧画面に戻るリンクを配置
 - ログインユーザーの注文履歴一覧、詳細
   - 一覧
     - 1つもない場合は「TOP」ー＞「商品一覧」かつ中央寄せ
 - 【管理】注文履歴一覧、詳細
   - 一覧
     - 「TOP」ー＞「商品一覧」
 - TOPページ用のヘッダーの画像を色を薄く変更
 - タイトル名を「使いやすいショッピングサイト」から「Spring Shopping」に変更

### 確認済み画面
 - 【管理】注文履歴一覧・詳細
 - 【管理】商品一覧・編集・追加
 - ログインユーザーの注文履歴一覧・詳細
 - あて先リスト一覧・編集・追加
 - 商品一覧・詳細
 - カート一覧
 - 注文・確認・完了
 - 新規登録・ログイン
